### PR TITLE
Add process to download pretrained models

### DIFF
--- a/modules/local/download_cellpose_model/.conda-lock/linux_amd64-bd-d098579826bbcf24_1.txt
+++ b/modules/local/download_cellpose_model/.conda-lock/linux_amd64-bd-d098579826bbcf24_1.txt
@@ -1,0 +1,6949 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-64:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-8_kmp_llvm.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.14.3-py312h5d8c7f2_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.13.3.post0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/annsel-0.1.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.14.1-pl5321h57e6904_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/arpack-3.9.1-nompi_hf03ea27_102.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.15.0-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.4-hb7a77c6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.14-h2aa3ae6_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.14.2-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h720e601_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.1-h6ffeea8_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.11.0-h38ae05a_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.27.3-h6f4d18d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.16.0-h21f4ec5_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.8-h46fcd08_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.7-h720e601_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h720e601_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.40.1-h102d43b_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.833-hc7390e0_9.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.14.0-hf596fc9_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.16.0-h1f05bef_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.7.0-py312h3f22e6b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.10.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-h505cf86_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-h9908984_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312he9c40d5_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brunsli-0.1-hd1e3526_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.3.3-hea3f660_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-2.0.1-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-2.0.1-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3c89d7e_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cellpose-3.1.1.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.1-py312h703531f_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.5.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.2.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.14-py312hd8ed1ab_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py312h4c3975b_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2026.8.0-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.8.0-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-image-2026.5.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.19.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-he8c428d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.8.0-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fast-array-utils-1.5-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fastremap-1.20.0-py312hf890105_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.1.2-gpl_h54862ce_905.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.5-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fill-voids-2.1.2-py312hf890105_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/flowio-1.4.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py312h8a5da7c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/formulaic-1.2.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h3a84ec1_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-h7cc23a3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py312h447239a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.7.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.8-h68053f1_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.4-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.4-pyha770c72_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h55b0958_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.3.1-h54a6638_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hb7133d2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glpk-5.0-h445213a_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.5.0-h980caa0_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hfd2156b_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.1-py312h04c1168_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312hfaa9938_104.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.4.0-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_110.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/igraph-1.0.1-hfe3e89f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2026.8.16-py312h3d3c6f4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.1-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/interface_meta-1.3.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.6.0-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.1-py312h9be0db6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h9073bf1_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.5-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.33.1-h7148c6a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h0dc7533_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.9-gpl_h3152399_101.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-25.0.0-hcc2f0d9_4_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-25.0.0-h635bf11_4_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-25.0.0-h53684a4_4_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-25.0.0-h635bf11_4_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-25.0.0-h66fbfdd_4_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.5-h434b012_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.4.2-h3ef1eba_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-10_h5875eb1_mkl.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-10_hfef963f_mkl.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp23.1-23.1.0-default_h0acdd01_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-23.1.0-default_h7855034_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.22.0-ha042cf0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdav1d7-1.5.4-hebe6cf0_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdovi-3.4.0-ha23c83e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.2-hd345f60_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-he503a2a_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.8.0-hbc29df5_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.8.0-hdbdcf42_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.82.1-h792040b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.4.0-h23af247_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.4.0-h23af247_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.4.0-h57c4cff_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.12.0-heb2dce7_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-haa4a5bd_1023.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-10_h5e43f62_mkl.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-10_hdba1596_mkl.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm23-23.1.0-h474f4eb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-5.0.0-qt6_hbd3298f_603.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h3133023_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.2.1-h1f0fae8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.2.1-h7e124b3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.2.1-h7e124b3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.2.1-hd41364c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.2.1-h1f0fae8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.2.1-h1f0fae8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.2.1-h1f0fae8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2026.2.1-hd41364c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2026.2.1-h607c73d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026.2.1-h607c73d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.2.1-hecca717_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.2.1-h21c0c73_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.2.1-hecca717_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-hebe6cf0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-25.0.0-h7376487_4_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libplacebo-7.360.1-hc50b9dd_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-7.35.1-h622638d_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.12.14-h0c77377_3_cpython.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libraqm-0.11.0-h6406941_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h60473fc_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h46dd2a8_20.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-gpl_hab3fe16_120.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.2.0-hdf11a46_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-hcc2c06a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.13.0-cpu_mkl_h40bd1c6_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.24.1-hb83e432_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hd2095e1_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h0e34353_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-h51789e4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-devel-2.15.3-h49c6c72_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.45-h8e12856_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-23.1.0-h7148c6a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.49.0-py312hb491018_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.1.2-py312h6b9c8db_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.5-py312h3d67a73_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-hee9eb32_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hebe6cf0_1003.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.11.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.1-py312h4c94fcb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-scalebar-0.9.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.2.2-hc2c9f91_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.1.0-hd2095e1_245.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.1.0-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-ha2cb11d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-ha2cb11d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-h8142553_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.2-py312h9be0db6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/multiscale-spatial-image-2.0.3-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-hee9eb32_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.25.0-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyhcf101f3_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.67.0-py312h80505a6_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.16.5-py312hf79963d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.2-py312he827f4e_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ome-types-0.6.3-pyhcf101f3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ome-zarr-0.18.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ome-zarr-models-1.6-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/onednn-3.12-omp_h83de36e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/opencv-5.0.0-qt6_h12f39d8_603.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.15-ha9edf89_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-h8c49934_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-heb1ab33_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.31.0-h8d634f6_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/optree-0.20.0-py312ha5105d2_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.1-h443056b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.5-py312h8ecdadd_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.58.2-h7bb47b9_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.4.2-pyhc455866_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pathlib-abc-0.5.2-pyh9692d8f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.3-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-h8b3dc9c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py312h38079b3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pims-0.7-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.6-pyh5ded981_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.8.1-he0df7b0_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.5.2-py312h8a5da7c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h1b36aeb_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h7cc23a3_1004.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-5.0.0-qt6_h6945e2d_603.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-25.0.0-py312h7900ff3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-25.0.0-py312h2054cf2_0_cpu.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.4-pyh293190f_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.4-pyh648e204_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyconify-0.2.1-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.6.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.5-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.5-py312hc767a74_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.15.0-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-zarr-0.10.0-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.6.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.13.0-py312hdb6ebaa_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.2-py312hb99b6cc_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.14.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.2-py312hf143aa3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.14-h5f976f7_3_cpython.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.3-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.14-hd8ed1ab_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-igraph-1.0.0-py312h1289d80_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-9_cp312.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.13.0-cpu_mkl_py312_h999dc20_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.3-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/rangehttpserver-1.4.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/readfcs-2.1.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/roifile-2026.7.30-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.6-hbcb56a7_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.12.4-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.26.0-np2py312h4ae17e4_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py312h3226591_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py312h54fa4ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/scverse-misc-0.1.4-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.16-h5330f5c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.4.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-81.0.0-pyh332efcf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shaderc-2026.3-hcebf71c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.1.2-py312h383787d_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/slicerator-1.1.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+- conda: https://conda.anaconda.org/bioconda/noarch/sopa-2.2.11-pyhdfd78af_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/spatial-image-1.2.3-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/spatialdata-0.8.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/spatialdata-io-0.7.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/spatialdata-plot-0.4.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.3-h7148c6a_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.4-h9ffa6c4_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.15.0-np2py312h32d774f_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/superqt-0.8.2-pyh9208f05_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.2.0-hd2095e1_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/texttable-1.7.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.8.23-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/toposort-1.10-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py312h4c3975b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.2-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.4-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/umap-learn-0.5.12-py312h7900ff3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/universal-pathlib-0.3.10-hd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/universal_pathlib-0.3.10-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-hc1c935e_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.4.0-py312h1b36aeb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h73f68a7_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.7.0-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-dataclass-3.0.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.17-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.3.0-h78fed68_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/xmltodict-1.0.4-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-h7cc23a3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-h7cc23a3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-h7cc23a3_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-h7cc23a3_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hebe6cf0_2.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-hebe6cf0_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.24.5-py312h8a5da7c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.3.0-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zfp-1.0.1-h909a3a2_5.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hce19668_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h1b36aeb_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-8_kmp_llvm.conda
+build_number: 8
+sha256: b8de006376660eb12c7fc40803c97e1480bf4bc1253f0d59694b12f81b52fe14
+md5: b4d1b93dd1dab4eea23395fd5e5b357d
+depends:
+- llvm-openmp >=9.0.1
+license: BSD-3-Clause
+license_family: BSD
+size: 8050
+timestamp: 1788046427177
+- conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_3.conda
+sha256: 2a7204314663eeda5dec482a956f0e2eaf289bd5b9953eaaaad0e81aa64638f2
+md5: 3845f3d75991bae0fb90884662f4327c
+depends:
+- cpython
+- python-gil
+license: MIT
+license_family: MIT
+size: 8144
+timestamp: 1784221492234
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
+sha256: 5ef589e5fd3736439781a9d48e68ce1e723b7081a471c02169908198eba4f448
+md5: e51e09bf3b91c62b7461a9f94e92c2c9
+depends:
+- python >=3.10
+license: PSF-2.0
+license_family: PSF
+size: 24690
+timestamp: 1782986823268
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.14.3-py312h5d8c7f2_0.conda
+sha256: 9195587d4ba2614c45ed1300a412869ee3d36b133d67197b3b2164263914b502
+md5: fe9eb34a1c0e51dfc5d98f41c5ddc8b8
+depends:
+- __glibc >=2.17,<3.0.a0
+- aiohappyeyeballs >=2.5.0
+- aiosignal >=1.4.0
+- attrs >=17.3.0
+- frozenlist >=1.1.1
+- libgcc >=14
+- multidict >=4.5,<7.0
+- propcache >=0.2.0
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+- typing_extensions >=4.4
+- yarl >=1.17.0,<2.0
+license: MIT AND Apache-2.0
+license_family: Apache
+size: 1087577
+timestamp: 1784901629231
+- conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+sha256: 8dc149a6828d19bf104ea96382a9d04dae185d4a03cc6beb1bc7b84c428e3ca2
+md5: 421a865222cd0c9d83ff08bc78bf3a61
+depends:
+- frozenlist >=1.1.0
+- python >=3.9
+- typing_extensions >=4.2
+license: Apache-2.0
+license_family: APACHE
+size: 13688
+timestamp: 1751626573984
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
+sha256: a35bddac04be093769e81814465a537961c6ed0f8d3cc23d6dce6ecdfaf71821
+md5: 7094e0d8d14de0eff6d83f0d2f1f661e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: LGPL-2.1-or-later
+license_family: LGPL
+size: 594986
+timestamp: 1787763412911
+- conda: https://conda.anaconda.org/conda-forge/noarch/anndata-0.13.3.post0-pyhd8ed1ab_0.conda
+sha256: 22f79e872295c9d2959627571697721cea90c0e5c344fab320a87debe0693a94
+md5: 35d13d079876f32cda60a40c44ef17aa
+depends:
+- array-api-compat >=1.7.1
+- h5py >=3.11
+- legacy-api-wrap
+- natsort
+- numpy >=2.1
+- packaging >=24.2
+- pandas >=2.3
+- pydantic-settings
+- python >=3.12
+- python-dotenv
+- scipy >=1.14,!=1.17.0
+- scverse-misc >=0.1.0
+- typing_extensions >=4.16
+- zarr >=3.1
+constrains:
+- awkward >=2.3.2
+- dask >=2023.5.1,!=2024.8.*,!=2024.9.*,!=2025.2.*,!=2025.3.*,!=2025.4.*,!=2025.5.*,!=2025.6.*,!=2025.7.*,!=2025.8.*
+- xarray >=2025.06.1
+license: BSD-3-Clause
+license_family: BSD
+size: 146200
+timestamp: 1787898570013
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.5-pyhcf101f3_0.conda
+sha256: a0a320c709fded9b5178108dedebf81a1f5a5d9c7720e3af50c1ab058dadd296
+md5: d68ec17cb915cab4642357417ec0a104
+depends:
+- python >=3.10
+- python
+license: MIT
+license_family: MIT
+size: 16785
+timestamp: 1785335690199
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.8.0-pyhd8ed1ab_0.conda
+sha256: b8fcb994134d3918d1c64a9d62f4168ff85d5bfb89e698102fe4ed679fe0df24
+md5: 108c928d2a8551832dbc762b535e90bb
+depends:
+- python >=3.10
+- typing-extensions >=4.0.0
+license: MIT
+license_family: MIT
+size: 19461
+timestamp: 1784935220549
+- conda: https://conda.anaconda.org/conda-forge/noarch/annsel-0.1.2-pyhd8ed1ab_0.conda
+sha256: fe4cb331e32624a391c6033d0e120d398ab0b1e2847e71c3314394e54997635e
+md5: 0fbb0e5c9aaa158c55de9feea164ae9c
+depends:
+- anndata
+- more-itertools >=10.7
+- narwhals >=2.14
+- pooch >=1.8.2
+- python >=3.10
+- session-info2
+- tqdm >=4
+- universal-pathlib >=0.2
+license: MIT
+license_family: MIT
+size: 22545
+timestamp: 1771350642241
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.14.1-pl5321h57e6904_2.conda
+sha256: bcfe516fdebf4503ab10c7968ee880774ce1adee6e055738ca53c81745cfdd58
+md5: 5fabcad67aa128f07f269066ee7fdde6
+depends:
+- libstdcxx >=15
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+license: BSD-2-Clause
+license_family: BSD
+size: 3246374
+timestamp: 1787256015178
+- conda: https://conda.anaconda.org/conda-forge/linux-64/arpack-3.9.1-nompi_hf03ea27_102.conda
+sha256: 6d71343420292132be0192ddd962b308f7b8a0a0630d1db83fb9d65e8167c6ce
+md5: e09af397232ef1070e0b6cbf4c64aacb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=13
+- libgfortran
+- libgfortran5 >=13.3.0
+- liblapack >=3.9.0,<4.0a0
+- libstdcxx >=13
+license: BSD-3-Clause
+license_family: BSD
+size: 130412
+timestamp: 1736083992796
+- conda: https://conda.anaconda.org/conda-forge/noarch/array-api-compat-1.15.0-pyhc364b38_0.conda
+sha256: 328865729d20c18ad2bb2472ae88dbe04e20291b4e36d9fab89d10b5a2badf35
+md5: c316aba22bb6b6f1e1cacc609c007973
+depends:
+- python >=3.10
+- python
+license: MIT
+license_family: MIT
+size: 62003
+timestamp: 1780923775972
+- conda: https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda
+sha256: 1b6124230bb4e571b1b9401537ecff575b7b109cc3a21ee019f65e083b8399ab
+md5: c6b0543676ecb1fb2d7643941fe375f2
+depends:
+- python >=3.10
+- python
+license: MIT
+license_family: MIT
+size: 64927
+timestamp: 1773935801332
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.10.4-hb7a77c6_1.conda
+sha256: 845fe32ee750d4a4d3efdb1d95a8c29c3388e3ea9787b77341ec4abe4e198b11
+md5: 4347d5ffdf34adf9c5edd10837727d96
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- aws-c-http >=0.11.0,<0.11.1.0a0
+- aws-c-io >=0.27.3,<0.27.4.0a0
+- aws-c-cal >=0.9.14,<0.9.15.0a0
+- aws-c-sdkutils >=0.2.7,<0.2.8.0a0
+- aws-c-common >=0.14.2,<0.14.3.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 135073
+timestamp: 1784086842394
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.14-h2aa3ae6_4.conda
+sha256: a67c944be1728f576c02fe8f28b0cbb78b5353415075db3da4ef71bc9dd8c00c
+md5: 9c6072e7b882d35ac956c07e493d6a9e
+depends:
+- __glibc >=2.17,<3.0.a0
+- aws-c-common >=0.14.2,<0.14.3.0a0
+- libgcc >=14
+- openssl >=3.5.7,<4.0a0
+license: Apache-2.0
+license_family: Apache
+size: 56752
+timestamp: 1784043396713
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.14.2-hb03c661_0.conda
+sha256: 701398f1c9978c41e93cb0947869a66b7f8004e9d6e548d63d11aedae83cfb02
+md5: f3e0b2e044485ae90d4a59c77e7a0182
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: Apache-2.0
+license_family: Apache
+size: 246263
+timestamp: 1783637234072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.2-h720e601_4.conda
+sha256: 8e0a5513cfc42df8bd16adbd8e83a37d3ca89b8e04cb20eb04eb177bbbfea365
+md5: c9be3f5854f349ae77a1a174b59e11a8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- aws-c-common >=0.14.2,<0.14.3.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 22301
+timestamp: 1784042853709
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.7.1-h6ffeea8_4.conda
+sha256: b1f35f7b7a5e745e2d56cf93212770bb56f5207fa9f0e38f98b0c05a1b898a90
+md5: 204d1e8d60c3ae839bd1898e4c7742c8
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- aws-checksums >=0.2.10,<0.2.11.0a0
+- aws-c-common >=0.14.2,<0.14.3.0a0
+- aws-c-io >=0.27.3,<0.27.4.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 59633
+timestamp: 1784075699558
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.11.0-h38ae05a_4.conda
+sha256: 4b939b4a76a11c9ec50c891ae9bf232da8dcaf8797701df1e79ae51c988be2d4
+md5: 97f2799ae6ff7b6f52dfa321fef9676b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- aws-c-compression >=0.3.2,<0.3.3.0a0
+- aws-c-io >=0.27.3,<0.27.4.0a0
+- aws-c-cal >=0.9.14,<0.9.15.0a0
+- aws-c-common >=0.14.2,<0.14.3.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 231294
+timestamp: 1784075685646
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.27.3-h6f4d18d_1.conda
+sha256: 94c32ca672ce290e250aea1cfb92582cca4658bdc3ec7cb1ceef254f34451595
+md5: bd19b685b88557830f1a617a6d404eb2
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- aws-c-cal >=0.9.14,<0.9.15.0a0
+- s2n >=1.7.5,<1.7.6.0a0
+- aws-c-common >=0.14.2,<0.14.3.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 183100
+timestamp: 1784054829913
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.16.0-h21f4ec5_2.conda
+sha256: 0252f072e2f493f8348575938c69b48b2799f29f0489c4ad2c5a919ab7e3d02e
+md5: 9728195c2f600ef427a1964ee193e707
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- aws-c-io >=0.27.3,<0.27.4.0a0
+- aws-c-http >=0.11.0,<0.11.1.0a0
+- aws-c-common >=0.14.2,<0.14.3.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 224933
+timestamp: 1784087527918
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.12.8-h46fcd08_1.conda
+sha256: a423bffbb0e6cacb5e2a0861b918ba3180e5132509afb1faf225ee9f0ec8f981
+md5: 706aa99414d18db5b23475b45cc93a0b
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- aws-c-io >=0.27.3,<0.27.4.0a0
+- aws-c-http >=0.11.0,<0.11.1.0a0
+- openssl >=3.5.7,<4.0a0
+- aws-c-cal >=0.9.14,<0.9.15.0a0
+- aws-c-auth >=0.10.4,<0.10.5.0a0
+- aws-checksums >=0.2.10,<0.2.11.0a0
+- aws-c-common >=0.14.2,<0.14.3.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 156174
+timestamp: 1784100985258
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.7-h720e601_2.conda
+sha256: e419e179e04021fc680d98af23fac4b4c2369cea61171087e57a734e968dd9bd
+md5: 816f62fa82532118ebb2398382090945
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- aws-c-common >=0.14.2,<0.14.3.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 68515
+timestamp: 1784044260935
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.10-h720e601_4.conda
+sha256: 6cc8617854a43040291dea791fe111ba408e7a5bbd9ee9e5a99375da7a16846b
+md5: 24ee781effc5779206a80139323c9caf
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- aws-c-common >=0.14.2,<0.14.3.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 101904
+timestamp: 1784044248506
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.40.1-h102d43b_3.conda
+sha256: e0c3a119c7035a00e0da325187ee723e07e0e6337e50362349d178ab40961f97
+md5: 3315ce09371baf6d70248b8927aa9866
+depends:
+- libstdcxx >=14
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- aws-c-sdkutils >=0.2.7,<0.2.8.0a0
+- aws-c-mqtt >=0.16.0,<0.16.1.0a0
+- aws-c-auth >=0.10.4,<0.10.5.0a0
+- aws-c-s3 >=0.12.8,<0.12.9.0a0
+- aws-c-common >=0.14.2,<0.14.3.0a0
+- aws-c-io >=0.27.3,<0.27.4.0a0
+- aws-c-event-stream >=0.7.1,<0.7.2.0a0
+- aws-c-cal >=0.9.14,<0.9.15.0a0
+- aws-c-http >=0.11.0,<0.11.1.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 416399
+timestamp: 1784113232967
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.833-hc7390e0_9.conda
+sha256: 0c15c036c3b71471eecc58bbe08a68c66fd6a051b548dca7675c7c924ed3972b
+md5: c65efa87d532339a090c87093097bf09
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+- aws-c-event-stream >=0.7.1,<0.7.2.0a0
+- aws-c-common >=0.14.2,<0.14.3.0a0
+- libcurl >=8.21.0,<9.0a0
+- aws-crt-cpp >=0.40.1,<0.40.2.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 3394321
+timestamp: 1784137257627
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.16.3-h206d751_0.conda
+sha256: fffc66e9be8806a92b314e27129c42b1298ea7065028c9e5d175dacb07829261
+md5: 0cabc152dc8896c3a4c4aebf2b308627
+depends:
+- __glibc >=2.17,<3.0.a0
+- libcurl >=8.19.0,<9.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.5,<4.0a0
+license: MIT
+license_family: MIT
+size: 349147
+timestamp: 1775238757304
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.13.3-h71f81a8_2.conda
+sha256: ebca774f1ebaa24c150730603b418b33fc7862811a16d097716b1a29f34798c5
+md5: f4fc754ec17176046988c46a54962a8c
+depends:
+- __glibc >=2.17,<3.0.a0
+- azure-core-cpp >=1.16.3,<1.16.4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 250737
+timestamp: 1781268163278
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.18.0-h74b55db_1.conda
+sha256: 04bb27dbf1d426b4447b28c3dc92ec01c807fa784eea86ffa1f8c2bd9b9e8076
+md5: 43151a3b0a8e037747d79a82dff9f967
+depends:
+- __glibc >=2.17,<3.0.a0
+- azure-core-cpp >=1.16.3,<1.16.4.0a0
+- azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 589716
+timestamp: 1781283775801
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.14.0-hf596fc9_1.conda
+sha256: 8a806f9852d280926d7613df548889b49e2a1c5d836385bcb2cedb24e7b08c64
+md5: 7896f4a6ee78538e2d0261e3b36dfa69
+depends:
+- __glibc >=2.17,<3.0.a0
+- azure-core-cpp >=1.16.3,<1.16.4.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libxml2
+- libxml2-16 >=2.14.6
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 159394
+timestamp: 1781268171097
+- conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-files-datalake-cpp-12.16.0-h1f05bef_1.conda
+sha256: 13e2e6eb942f65bf81e9089bf6b5926534d9245c781288c5270beb3a25c9156b
+md5: 70972c9cb0893d6499dd4118415a966b
+depends:
+- __glibc >=2.17,<3.0.a0
+- azure-core-cpp >=1.16.3,<1.16.4.0a0
+- azure-storage-blobs-cpp >=12.18.0,<12.18.1.0a0
+- azure-storage-common-cpp >=12.14.0,<12.14.1.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 308699
+timestamp: 1781538835962
+- conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.7.0-py312h3f22e6b_1.conda
+sha256: b377a4f053c4e184b031253c702984194d10c98228004d7cf07c1eca86247d62
+md5: b0e9b44b494bb001c4d35b206022eba2
+depends:
+- python
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- python_abi 3.12.* *_cp312
+- zstd >=1.5.7,<1.6.0a0
+license: BSD-3-Clause AND MIT AND EPL-2.0
+size: 241113
+timestamp: 1788491295568
+- conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+sha256: e7af5d1183b06a206192ff440e08db1c4e8b2ca1f8376ee45fb2f3a85d4ee45d
+md5: 2c2fae981fd2afd00812c92ac47d023d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libstdcxx >=13
+- libzlib >=1.3.1,<2.0a0
+- lz4-c >=1.10.0,<1.11.0a0
+- snappy >=1.2.1,<1.3.0a0
+- zstd >=1.5.6,<1.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 48427
+timestamp: 1733513201413
+- conda: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.10.0-pyhd8ed1ab_0.conda
+sha256: 34bb5cc4f6ccff1e410dea2d39880190f88a8be7ad5cfe9ff0da2cf3d2ad7ea1
+md5: 67d0ed593951a4933024453b76ef1355
+depends:
+- contourpy >=1.2
+- jinja2 >=2.9
+- narwhals >=1.13
+- numpy >=1.16
+- packaging >=16.8
+- pillow >=7.1.0
+- python >=3.12
+- pyyaml >=3.10
+- tornado >=6.2
+- xyzservices >=2021.09.1
+constrains:
+- panel >=1.8.10
+license: BSD-3-Clause
+license_family: BSD
+size: 4454345
+timestamp: 1787144786949
+- conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
+sha256: 1acf87c77d920edd098ddc91fa785efc10de871465dee0f463815b176e019e8b
+md5: 1fcdf88e7a8c296d3df8409bf0690db4
+depends:
+- jinja2 >=3
+- python >=3.10
+license: MIT
+license_family: MIT
+size: 30176
+timestamp: 1759755695447
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.2.0-h505cf86_4.conda
+sha256: 61b78574f002390b6a7fc79834fc344beaab09550068a51100eea5a485dac741
+md5: 746aa619a1bcaf4da541101179d7c60e
+depends:
+- __glibc >=2.17,<3.0.a0
+- brotli-bin 1.2.0 h9908984_4
+- libbrotlidec 1.2.0 ha411449_4
+- libbrotlienc 1.2.0 h018ffa1_4
+- libgcc >=15
+license: MIT
+size: 20679
+timestamp: 1788480401508
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.2.0-h9908984_4.conda
+sha256: ce7db81d5fd4b222ee1a27c52ccf7af44faaf88283017103a8e288f9c372b973
+md5: c48c09444f3736800ea0b9550c365baf
+depends:
+- __glibc >=2.17,<3.0.a0
+- libbrotlidec 1.2.0 ha411449_4
+- libbrotlienc 1.2.0 h018ffa1_4
+- libgcc >=15
+license: MIT
+size: 21601
+timestamp: 1788480392621
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312he9c40d5_4.conda
+sha256: 6e4f440a7015d7d78120b3a3f90a4ec3d7bb6de7bc65458123c52433755db5f0
+md5: edb667e7ce56106424e8afab2dc0f0cb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+constrains:
+- libbrotlicommon 1.2.0 h39a168f_4
+license: MIT
+size: 367657
+timestamp: 1788480501027
+- conda: https://conda.anaconda.org/conda-forge/linux-64/brunsli-0.1-hd1e3526_2.conda
+sha256: b4831ac06bb65561342cedf3d219cf9b096f20b8d62cda74f0177dffed79d4d5
+md5: 5948f4fead433c6e5c46444dbfb01162
+depends:
+- __glibc >=2.17,<3.0.a0
+- libbrotlicommon >=1.2.0,<1.3.0a0
+- libbrotlidec >=1.2.0,<1.3.0a0
+- libbrotlienc >=1.2.0,<1.3.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 168501
+timestamp: 1761758949420
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+md5: e675fabcf81499adc7edf58124fb1e01
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+size: 257808
+timestamp: 1785906269155
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+md5: 3ad2b403be8fc5612b9159e2ce621f69
+depends:
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 228700
+timestamp: 1787169971173
+- conda: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-3.3.3-hea3f660_0.conda
+sha256: 2b9197486cbd6b0d33426168576df9c5b844c8339e43e029685cd78b2fbdbb68
+md5: fe68c12d33323abd558a30821975133f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+- lz4-c >=1.10.0,<1.11.0a0
+- zlib-ng >=2.3.3,<2.4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 413573
+timestamp: 1788179307405
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
+depends:
+- __unix
+license: ISC
+size: 131780
+timestamp: 1784754889428
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-2.0.1-pyhcf101f3_0.conda
+sha256: 39358005c3cc44d8315ed79789b18a960d69365be979970cc6bae8f7a6177703
+md5: 70e764e549c6c25de5e429d6e4a28b39
+depends:
+- cached_property >=2.0.1,<2.0.2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 3720
+timestamp: 1787678456483
+- conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-2.0.1-pyhcf101f3_0.conda
+sha256: 4bd96dab5a434e4ee59fb6910cae704d4c5b453907d4886272a9943d37e42b6f
+md5: 256d863ded0f79464391a075944d24a6
+depends:
+- python >=3.10
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 16597
+timestamp: 1787678456483
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3c89d7e_3.conda
+sha256: 6b551d9346997bc4c6fadf96b7b92442b8f3244011cc462e4ee77afc714d52c5
+md5: 7b870cffbaa8430290e567a0facd8dca
+depends:
+- __glibc >=2.17,<3.0.a0
+- fontconfig >=2.18.3,<3.0a0
+- fonts-conda-ecosystem
+- icu >=78.3,<79.0a0
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=15
+- libglib >=2.88.3,<3.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=15
+- libxcb >=1.17.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- pixman >=0.46.4,<1.0a0
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxext >=1.3.7,<2.0a0
+- xorg-libxrender >=0.9.12,<0.10.0a0
+license: LGPL-2.1-only or MPL-1.1
+size: 991011
+timestamp: 1788221336073
+- conda: https://conda.anaconda.org/conda-forge/noarch/cellpose-3.1.1.3-pyhd8ed1ab_0.conda
+sha256: 0ba5f2f342b69a25e1ecd9367970d482f77ce12d27022ae748c98686d1e72670
+md5: 13014f945fd5dd949c31e86ab20c13e3
+depends:
+- dask-core
+- dask-image
+- fastremap
+- fill-voids
+- imagecodecs
+- llvmlite
+- matplotlib-base
+- natsort
+- numba >=0.53.0
+- numpy >=1.20.0
+- opencv
+- pyqtgraph >=0.11.0rc0
+- pyside6
+- python >=3.10
+- pytorch >=1.6
+- qtpy
+- roifile
+- scikit-image
+- scikit-learn
+- scipy
+- superqt
+- tifffile
+- tqdm
+license: BSD-3-Clause
+license_family: BSD
+size: 195822
+timestamp: 1767986946382
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.7.22-pyhd8ed1ab_0.conda
+sha256: fb167de4388e64e52aa3907ed099afab944c1fa6e5f74b281a312dae1bcf7f3b
+md5: 37e13edbe3b48f1095a9d085ef9cd83b
+depends:
+- python >=3.10
+license: ISC
+size: 137015
+timestamp: 1784717699092
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.1-py312h703531f_3.conda
+sha256: 7c6e8b24d62e0bfa5d14050cd29053778f399feefa7d6887b04575210285a849
+md5: 41f019d067f8c52c6d9283d8afb28889
+depends:
+- __glibc >=2.17,<3.0.a0
+- libffi >=3.7.0,<3.8.0a0
+- libgcc >=15
+- pycparser
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: MIT
+size: 302937
+timestamp: 1788485303634
+- conda: https://conda.anaconda.org/conda-forge/linux-64/charls-2.4.4-hecca717_0.conda
+sha256: 285bb88f6229a1eb4772ab805fbc61ef786e27b5e9ca0b6434b13d2a728790bb
+md5: dc7072d888ba25c06d706d9dd4bd48ec
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 162240
+timestamp: 1780948654621
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.5.1-pyhd8ed1ab_0.conda
+sha256: cb60ef3e0631c8bacb4f7057196dee4496091a22baa3bb4b9bccb12c7e1c921b
+md5: e0ac3accc64e23e40969d660e5f58ac8
+depends:
+- python >=3.10
+license: MIT
+license_family: MIT
+size: 64487
+timestamp: 1786835648298
+- conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.2-pyhc90fa1f_0.conda
+sha256: ccc4787f511964f9a1f2d2d2859c91c5d571fb60f7f09d4c4e092c9b7a94e671
+md5: 2c4bd6aeb90bb157456841c3270a0d92
+depends:
+- __unix
+- python
+- python >=3.10
+license: BSD-3-Clause
+license_family: BSD
+size: 107155
+timestamp: 1783085363526
+- conda: https://conda.anaconda.org/conda-forge/noarch/cloudpickle-3.1.2-pyhcf101f3_1.conda
+sha256: 4c287c2721d8a34c94928be8fe0e9a85754e90189dd4384a31b1806856b50a67
+md5: 61b8078a0905b12529abc622406cb62c
+depends:
+- python >=3.10
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 27353
+timestamp: 1765303462831
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
+md5: 962b9857ee8e7018c22f2776ffa0b2d7
+depends:
+- python >=3.9
+license: BSD-3-Clause
+license_family: BSD
+size: 27011
+timestamp: 1733218222191
+- conda: https://conda.anaconda.org/conda-forge/noarch/colorcet-3.2.1-pyhd8ed1ab_0.conda
+sha256: f863dd6ab7302a40bf7e1e98bc963a1de1530d1277e609865f84c53907af4b13
+md5: 0b6419b9a27c540bd96e66e12a44c379
+depends:
+- python >=3.10
+license: CC-BY-4.0
+size: 174387
+timestamp: 1777396861701
+- conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
+sha256: 62447faf7e8eb691e407688c0b4b7c230de40d5ecf95bf301111b4d05c5be473
+md5: 43c2bc96af3ae5ed9e8a10ded942aa50
+depends:
+- numpy >=1.25
+- python
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+- python_abi 3.12.* *_cp312
+license: BSD-3-Clause
+license_family: BSD
+size: 320386
+timestamp: 1769155979897
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.14-py312hd8ed1ab_3.conda
+noarch: generic
+sha256: 1052869d599008850098c033f9568a2e28bb31238705969719be69a87474cc93
+md5: adee9213d9a98d7f8b5627209c8b4ae0
+depends:
+- python >=3.12,<3.13.0a0
+- python_abi * *_cp312
+license: Python-2.0
+size: 47172
+timestamp: 1788391292962
+- conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
+sha256: bb47aec5338695ff8efbddbc669064a3b10fe34ad881fb8ad5d64fbfa6910ed1
+md5: 4c2a8fef270f6c69591889b93f9f55c1
+depends:
+- python >=3.10
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 14778
+timestamp: 1764466758386
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+sha256: 7684da83306bb69686c0506fb09aa7074e1a55ade50c3a879e4e5df6eebb1009
+md5: af491aae930edc096b58466c51c4126c
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=13
+- libntlm >=1.8,<2.0a0
+- libstdcxx >=13
+- libxcrypt >=4.4.36
+- openssl >=3.5.5,<4.0a0
+license: BSD-3-Clause-Attribution
+license_family: BSD
+size: 210103
+timestamp: 1771943128249
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py312h4c3975b_2.conda
+sha256: 75b3d3c9497cded41e029b7a0ce4cc157334bbc864d6701221b59bb76af4396d
+md5: 29fd0bdf551881ab3d2801f7deaba528
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+- toolz >=0.10.0
+license: BSD-3-Clause
+license_family: BSD
+size: 623770
+timestamp: 1771855837505
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-2026.8.0-pyhc364b38_0.conda
+sha256: 757750c674117059fde8114f305591f1b4ee8f446b11274278151e88fdcf61c6
+md5: e79afa78ebd31bb1e76de5fe117edb29
+depends:
+- python >=3.10
+- dask-core >=2026.8.0,<2026.8.1.0a0
+- distributed >=2026.8.0,<2026.8.1.0a0
+- cytoolz >=0.11.2
+- lz4 >=4.3.2
+- numpy >=1.26
+- pandas >=2.0
+- bokeh >=3.1.0
+- jinja2 >=2.10.3
+- pyarrow >=16.0
+- python
+constrains:
+- openssl !=1.1.1e
+license: BSD-3-Clause
+license_family: BSD
+size: 10415
+timestamp: 1787917206356
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2026.8.0-pyhc364b38_0.conda
+sha256: 1126e38c6763e5c9ab3885f859c0111bd5e7abcf346a9037655177ef7ae06909
+md5: 2ccdf45d2372e15c7edcb7a72d573e76
+depends:
+- python >=3.10
+- click >=8.1
+- cloudpickle >=3.0.0
+- fsspec >=2021.9.0
+- packaging >=20.0
+- partd >=1.4.0
+- pyyaml >=5.4.1
+- toolz >=0.12.0
+- importlib-metadata >=4.13.0
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 1071072
+timestamp: 1787845029550
+- conda: https://conda.anaconda.org/conda-forge/noarch/dask-image-2026.5.0-pyhd8ed1ab_1.conda
+sha256: 35e19970c7617e45a873b3eed61f483468194262c0bd562db3eecbf9715195fd
+md5: ac6fe95a657baa8a01f9cc38d60483a0
+depends:
+- dask-core >=2024.4.1
+- numpy >=1.18
+- pims >=0.4.1
+- python >=3.10
+- scipy >=1.7.0
+- tifffile >=2020.10.1
+constrains:
+- pandas >=2.0.0
+- dask >=2024.4.1
+license: BSD-3-Clause
+license_family: BSD
+size: 56812
+timestamp: 1780677721002
+- conda: https://conda.anaconda.org/conda-forge/noarch/datashader-0.19.1-pyhd8ed1ab_0.conda
+sha256: a440eb220a07eb7517334396f0f783a356bf43ffb22b1441e61f394640ccfbe2
+md5: 51ec314f84fd5215980646e84f6f54dc
+depends:
+- colorcet
+- multipledispatch
+- numba
+- numpy
+- packaging
+- pandas
+- param
+- pyct
+- python >=3.10
+- requests
+- scipy
+- toolz
+- xarray
+license: BSD-3-Clause
+license_family: BSD
+size: 9604478
+timestamp: 1779195887051
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+md5: 418c6ca5929a611cbd69204907a83995
+depends:
+- libgcc-ng >=12
+license: BSD-2-Clause
+license_family: BSD
+size: 760229
+timestamp: 1685695754230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-he8c428d_2.conda
+sha256: 87a0a42d4ccc527597eff3234509dfb03e0d9bf67d5e2b6fc758e2ef389d8abe
+md5: a6eb37b51be1a9a654dc3a8aca039b1a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+- libexpat >=2.8.1,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+- libglib >=2.88.3,<3.0a0
+license: AFL-2.1 OR GPL-2.0-or-later
+size: 449564
+timestamp: 1788197922783
+- conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_1.conda
+sha256: 7d57a7b8266043ffb99d092ebc25e89a0a2490bed4146b9432c83c2c476fa94d
+md5: 5498feb783ab29db6ca8845f68fa0f03
+depends:
+- python >=3.10
+- wrapt <3,>=1.10
+license: MIT
+license_family: MIT
+size: 15896
+timestamp: 1768934186726
+- conda: https://conda.anaconda.org/conda-forge/noarch/distributed-2026.8.0-pyhc364b38_0.conda
+sha256: 3dd953eba3c59ecfac0e8cdaa47d5017f48a1843c8b0ad07cb743563e9d64bc6
+md5: f382c4eed5376ee372a6e67a0f6cd4d9
+depends:
+- python >=3.10
+- click >=8.0
+- cloudpickle >=3.0.0
+- cytoolz >=0.12.0
+- dask-core >=2026.8.0,<2026.8.1.0a0
+- jinja2 >=2.10.3
+- locket >=1.0.0
+- msgpack-python >=1.0.2
+- packaging >=20.0
+- psutil >=5.8.0
+- pyyaml >=5.4.1
+- sortedcontainers >=2.0.5
+- tblib >=1.6.0
+- toolz >=0.12.0
+- tornado >=6.2.0
+- zict >=3.0.0
+- python
+constrains:
+- openssl !=1.1.1e
+license: BSD-3-Clause
+license_family: BSD
+size: 840592
+timestamp: 1787863556779
+- conda: https://conda.anaconda.org/conda-forge/noarch/donfig-0.8.1.post1-pyhd8ed1ab_1.conda
+sha256: d58e97d418f71703e822c422af5b9c431e3621a0ecdc8b0334c1ca33e076dfe7
+md5: c56a7fa5597ad78b62e1f5d21f7f8b8f
+depends:
+- python >=3.9
+- pyyaml
+license: MIT
+license_family: MIT
+size: 22491
+timestamp: 1734368817583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/double-conversion-3.4.0-hecca717_0.conda
+sha256: 40cdd1b048444d3235069d75f9c8e1f286db567f6278a93b4f024e5642cfaecc
+md5: dbe3ec0f120af456b3477743ffd99b74
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 71809
+timestamp: 1765193127016
+- conda: https://conda.anaconda.org/conda-forge/noarch/fast-array-utils-1.5-pyhd8ed1ab_0.conda
+sha256: 7c45e7a353be87a0cc2ecd8edac7a27ce3d74db77c712164296455e0b9da8319
+md5: 0a9e144407cdaf3ec2383c3a3021c1b0
+depends:
+- array-api-compat
+- numpy >=2
+- python >=3.12
+constrains:
+- dask >=2023.6.1
+- numba >=0.57
+- scipy >=1.13
+license: MPL-2.0
+license_family: MOZILLA
+size: 42293
+timestamp: 1784368664244
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fastremap-1.20.0-py312hf890105_0.conda
+sha256: 50bcf0481c256466e39f88ac20204f06bc41f6df22741d8ea33f34c256f07478
+md5: 37ac3c63c10db30aa2be869d26be7c8b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- numpy >=1.23,<3
+- packaging
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: LGPL-3.0-only
+license_family: LGPL
+size: 614190
+timestamp: 1781221575409
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.1.2-gpl_h54862ce_905.conda
+sha256: 59bd8554462bb627dbd5366f7b7ec8cfef367a576a701001432535213ed162d2
+md5: 31470f3f39e09c35310f26a948a337a0
+depends:
+- __glibc >=2.17,<3.0.a0
+- alsa-lib >=1.2.16.1,<1.3.0a0
+- aom >=3.14.1,<3.15.0a0
+- bzip2 >=1.0.8,<2.0a0
+- dav1d >=1.2.1,<1.2.2.0a0
+- fontconfig >=2.18.2,<3.0a0
+- fonts-conda-ecosystem
+- gmp >=6.3.0,<7.0a0
+- lame >=3.100,<3.101.0a0
+- libass >=0.17.5,<0.17.6.0a0
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libharfbuzz >=14.3.0
+- libiconv >=1.18,<2.0a0
+- libjxl >=0.12.0,<0.13.0a0
+- liblzma >=5.8.3,<6.0a0
+- libopenvino >=2026.2.1,<2026.2.2.0a0
+- libopenvino-auto-batch-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-auto-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-hetero-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-intel-cpu-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-intel-gpu-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-intel-npu-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-ir-frontend >=2026.2.1,<2026.2.2.0a0
+- libopenvino-onnx-frontend >=2026.2.1,<2026.2.2.0a0
+- libopenvino-paddle-frontend >=2026.2.1,<2026.2.2.0a0
+- libopenvino-pytorch-frontend >=2026.2.1,<2026.2.2.0a0
+- libopenvino-tensorflow-frontend >=2026.2.1,<2026.2.2.0a0
+- libopenvino-tensorflow-lite-frontend >=2026.2.1,<2026.2.2.0a0
+- libopus >=1.6.1,<2.0a0
+- libplacebo >=7.360.1,<7.361.0a0
+- librsvg >=2.62.3,<3.0a0
+- libstdcxx >=14
+- libva >=2.24.1,<3.0a0
+- libvorbis >=1.3.7,<1.4.0a0
+- libvpl >=2.16.0,<2.17.0a0
+- libvpx >=1.15.2,<1.16.0a0
+- libvulkan-loader >=1.4.357.0,<2.0a0
+- libwebp-base >=1.6.0,<2.0a0
+- libxcb >=1.17.0,<2.0a0
+- libxml2
+- libxml2-16 >=2.14.6
+- libzlib >=1.3.2,<2.0a0
+- openh264 >=2.6.0,<2.6.1.0a0
+- openssl >=3.5.7,<4.0a0
+- pulseaudio-client >=17.0,<17.1.0a0
+- sdl2 >=2.32.56,<3.0a0
+- shaderc >=2026.3,<2026.4.0a0
+- svt-av1 >=4.2.0,<4.2.1.0a0
+- x264 >=1!164.3095,<1!165
+- x265 >=3.5,<3.6.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+constrains:
+- __cuda  >=12.8
+license: GPL-2.0-or-later
+license_family: GPL
+size: 13030090
+timestamp: 1785947542690
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.32.5-pyhd8ed1ab_0.conda
+sha256: a52faa011a8176bbbf30c77f76707788be9a9e1a7e30c3753083719c093a15dc
+md5: 9b091d04be6b722d4ed7dfee34295dea
+depends:
+- python >=3.10
+license: Unlicense
+size: 78858
+timestamp: 1788217445739
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fill-voids-2.1.2-py312hf890105_0.conda
+sha256: 9b914adc74c6a428abd2ecc555dbe182b1a98b12d2920d17a55df2c34b7e04e4
+md5: 3123d77894ec82691fd32d4e29505284
+depends:
+- __glibc >=2.17,<3.0.a0
+- fastremap
+- libgcc >=14
+- libstdcxx >=14
+- numpy >=1.23,<3
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: LGPL-3.0-only
+license_family: LGPL
+size: 210779
+timestamp: 1777532568381
+- conda: https://conda.anaconda.org/conda-forge/noarch/flexcache-0.3-pyhd8ed1ab_1.conda
+sha256: acdb7b73d84268773fcc8192965994554411edc488ec3447925a62154e9d3baa
+md5: f1e618f2f783427019071b14a111b30d
+depends:
+- python >=3.9
+- typing-extensions
+license: BSD-3-Clause
+license_family: BSD
+size: 16674
+timestamp: 1733663669958
+- conda: https://conda.anaconda.org/conda-forge/noarch/flexparser-0.4-pyhd8ed1ab_1.conda
+sha256: 9bdad0cd9fb6d67e48798c03930d634ea2d33a894d30439d3d7bdffd3c21af7b
+md5: 6dc4e43174cd552452fdb8c423e90e69
+depends:
+- python >=3.9
+- typing-extensions
+- typing_extensions
+license: BSD-3-Clause
+license_family: BSD
+size: 28686
+timestamp: 1733663636245
+- conda: https://conda.anaconda.org/conda-forge/noarch/flowio-1.4.0-pyhd8ed1ab_0.conda
+sha256: 9b02c08d95c634518dabeb3906602b6127c69422ca169589c6b4356a95fd5048
+md5: 7aa0d3714e92ececee74b9ec2cb4954a
+depends:
+- numpy >=1.19.3
+- python >=3.10
+license: BSD-3-Clause
+license_family: BSD
+size: 25432
+timestamp: 1764765651914
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-h76c4fd7_1.conda
+sha256: 25d14a197601fdd616f2e501431b52887e69b31e7defbc1679381d718357ceb7
+md5: a70bb6d42ad121aef456e0007e92bed6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 199072
+timestamp: 1785915412102
+- conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
+sha256: 782fa186d7677fd3bc1ff7adb4cc3585f7d2c7177c30bcbce21f8c177135c520
+md5: a6997a7dcd6673c0692c61dfeaea14ab
+depends:
+- branca >=0.6.0
+- jinja2 >=2.9
+- numpy
+- python >=3.9
+- requests
+- xyzservices
+license: MIT
+license_family: MIT
+size: 82665
+timestamp: 1750113928159
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+md5: 0c96522c6bdaed4b1566d11387caaf45
+license: BSD-3-Clause
+license_family: BSD
+size: 397370
+timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+md5: 34893075a5c9e55cdafac56607368fc6
+license: OFL-1.1
+license_family: Other
+size: 96530
+timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+md5: 4d59c254e01d9cde7957100457e2d5fb
+license: OFL-1.1
+license_family: Other
+size: 700814
+timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+md5: 49023d73832ef61042f6a237cb2687e7
+license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+license_family: Other
+size: 1620504
+timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+sha256: 5a3eb10b18a97223ab06b3a7f0d7f56658db2f2800e2f2af95836fe3bf55ba63
+md5: 922776b528a470ab5afa81fd42abfa1d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=15
+- libuuid >=2.42.2,<3.0a0
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 296288
+timestamp: 1786667377340
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+md5: fee5683a3f04bd15cbd8318b096a27ab
+depends:
+- fonts-conda-forge
+license: BSD-3-Clause
+license_family: BSD
+size: 3667
+timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+md5: a7970cd949a077b7cb9696379d338681
+depends:
+- font-ttf-ubuntu
+- font-ttf-inconsolata
+- font-ttf-dejavu-sans-mono
+- font-ttf-source-code-pro
+license: BSD-3-Clause
+license_family: BSD
+size: 4059
+timestamp: 1762351264405
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.63.0-py312h8a5da7c_0.conda
+sha256: d235ae7075642044ceb3d922ef2a710a82665755ac9bbb7e8dad7daa72bc6d87
+md5: 294fb524171e2a2748cb7fe708aba826
+depends:
+- __glibc >=2.17,<3.0.a0
+- brotli
+- libgcc >=14
+- munkres
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+- unicodedata2 >=15.1.0
+license: MIT
+license_family: MIT
+size: 3007892
+timestamp: 1778770568019
+- conda: https://conda.anaconda.org/conda-forge/noarch/formulaic-1.2.2-pyhd8ed1ab_0.conda
+sha256: a6e065128ef1f2b6b2636268409155c1013460babb619e6e8415686305e776ea
+md5: f18f43fb3e20ab309d46faebfb3348b0
+depends:
+- interface_meta >=1.2
+- narwhals >=1.17
+- numpy >=1.20
+- pandas >=1.3
+- python >=3.10
+- scipy >=1.6
+- typing-extensions >=4.2
+- wrapt >=1.17
+constrains:
+- polars >=1
+- pyarrow >=1
+- sympy >=1.3,!=1.10
+license: MIT
+license_family: MIT
+size: 90142
+timestamp: 1780453843138
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.3-ha770c72_2.conda
+sha256: 612a8e0c1a6ecae23da54d81ef395f6ebb5c8e4468ec2611593ebce75876a4e0
+md5: 2d0ea23b23603e07ca47f23f949f67b6
+depends:
+- libfreetype 2.14.3 ha770c72_2
+- libfreetype6 2.14.3 h5e6c136_2
+license: GPL-2.0-only OR FTL
+size: 175239
+timestamp: 1786641011029
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h3a84ec1_3.conda
+sha256: f154843c5ac16d6cbe6297292c82ed65462aca9749f2f8722b166f47165fbcff
+md5: 66ee86d087145e4d91d8a75437692238
+depends:
+- __glibc >=2.17,<3.0.a0
+- libexpat >=2.8.1,<3.0a0
+- libgcc >=15
+- libiconv >=1.18,<2.0a0
+- minizip >=4.2.2,<5.0a0
+license: MPL-1.1
+license_family: MOZILLA
+size: 61858
+timestamp: 1788125490606
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-h7cc23a3_2.conda
+sha256: 76dd097bd65d812a9104edb0e266386e152e65928ac5c8eb4f480ce24affc470
+md5: 16d6e5a0f8dbc17bd6669dba6f49bad3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: LGPL-2.1-or-later
+size: 62401
+timestamp: 1788385624706
+- conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py312h447239a_0.conda
+sha256: 7f36a4fc42f6d4cb9c5b210b6604b54eba2e5745c92d76241b6f8fce446818d1
+md5: 6a42923f35087cc88a9fac31ef096ce6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: Apache-2.0
+license_family: APACHE
+size: 55016
+timestamp: 1779999817627
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.7.0-pyhd8ed1ab_0.conda
+sha256: 3cd1c985695d8114bdba2a4a38c87e86d633fadd7cfe7a6733ebb3fe807fdc86
+md5: b9176565976c773a0739bd83deaf06cc
+depends:
+- python >=3.10
+license: BSD-3-Clause
+license_family: BSD
+size: 151868
+timestamp: 1785325238671
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.8-h68053f1_2.conda
+sha256: 32f3ebd1871cb6ac7eac36c78c410860f38e8d252d5857a80f6abfcb79c7e0ff
+md5: d7bd6ccfc58eb6796bd6bba85878fc0e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libglib >=2.88.3,<3.0a0
+- libjpeg-turbo >=3.2.0,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libtiff >=4.7.2,<4.8.0a0
+license: LGPL-2.1-or-later
+license_family: LGPL
+size: 581961
+timestamp: 1788490424411
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.4-pyhd8ed1ab_0.conda
+sha256: cd478c0835106afce2478d6dcc525854219c4e710c7b446e2dd5042bfc9da082
+md5: 99d77e0f92f7b0b977f77cfb49c7eaf6
+depends:
+- folium
+- geopandas-base 1.1.4 pyha770c72_0
+- mapclassify >=2.5.0
+- matplotlib-base
+- pyogrio >=0.7.2
+- pyproj >=3.5.0
+- python >=3.10
+- xyzservices
+license: BSD-3-Clause
+license_family: BSD
+size: 8267
+timestamp: 1782507446937
+- conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.4-pyha770c72_0.conda
+sha256: 77d0527d91c2a4bba135fdffb30557c88bacc22d7440c6632502609dd1ef0ab6
+md5: 6e31007c02f361338281bb78c5b84e7c
+depends:
+- numpy >=1.24
+- packaging
+- pandas >=2.0.0
+- python >=3.10
+- shapely >=2.0.0
+license: BSD-3-Clause
+license_family: BSD
+size: 255909
+timestamp: 1782507445933
+- conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h55b0958_0.conda
+sha256: dc9f03bef913c8b3c94e93a61318b7437bd5e4f7136ef841e68df8de082405d5
+md5: 5f856b72ca9cd5b5b4a1c43551804622
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+license: LGPL-2.1-only
+size: 2002850
+timestamp: 1787893677347
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.3.1-h54a6638_0.conda
+sha256: f7026323ac769ef432c747a6c22abd39c583d0d4f6985a7100fb371e2167f214
+md5: 04be12e7dd050aaf364ece2393988e85
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 130991
+timestamp: 1785044715896
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+sha256: 3611c5d605cd56017704e6c01c7bd849e74a656a546d4c49d655fde49ddfeecc
+md5: bd7c3a8586ed0101f094962100d30a63
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 77403
+timestamp: 1784694210187
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hb7133d2_1.conda
+sha256: f24feeda3aeec3a2cbb9fe2e0fabc4785372e70b6cc838c96023e08e17f4bfa0
+md5: 6941f96b8a8056677d79b4f5a2c4aaca
+depends:
+- __glibc >=2.17,<3.0.a0
+- gflags >=2.3.0,<2.4.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 149031
+timestamp: 1784094370091
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glpk-5.0-h445213a_0.tar.bz2
+sha256: 0e19c61198ae9e188c43064414a40101f5df09970d4a2c483c0c46a6b1538966
+md5: efc4b0c33bdf47312ad5a8a0587fa653
+depends:
+- gmp >=6.2.1,<7.0a0
+- libgcc-ng >=9.3.0
+license: GPL-3.0-or-later
+license_family: GPL
+size: 1047292
+timestamp: 1624569176979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.5.0-h980caa0_2.conda
+sha256: 2c2eb8deb61d781c3b1bae69e6b8de3fe9cbb18049493de4578a65ca8068090a
+md5: f8cf8d6c2f5a98e7263d461c8514cb8a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+- spirv-tools >=2026,<2027.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1437572
+timestamp: 1787686922356
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hfd2156b_3.conda
+sha256: f36c336efc874f346a53a9011f67e997f9faac505562cc18c13b6d399cfe61c7
+md5: 576e32739f323438bf69ab006c21be7b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: GPL-2.0-or-later OR LGPL-3.0-or-later
+size: 493498
+timestamp: 1786629164954
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.1-py312h04c1168_0.conda
+sha256: 8f1abde65e50bf2f30292442a5388bf962f8275bb1e23a0fe8fbdc83b8b5a241
+md5: 96a25063461871ac66728ecfa645116c
+depends:
+- python
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- mpfr >=4.2.2,<5.0a0
+- gmp >=6.3.0,<7.0a0
+- python_abi 3.12.* *_cp312
+- mpc >=1.4.0,<2.0a0
+license: LGPL-3.0-or-later
+license_family: LGPL
+size: 327022
+timestamp: 1787066358050
+- conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda
+sha256: 3f962b2cbdc2aac3089a5c708477657266c0a665f0eed09981a34d1ab6793065
+md5: 68f704ea294dcec9e09edd9c3d233846
+depends:
+- __glibc >=2.17,<3.0.a0
+- libcrc32c >=1.1.2,<1.2.0a0
+- libgcc >=14
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: Apache-2.0
+license_family: Apache
+size: 24900
+timestamp: 1768549198202
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+sha256: 7fa3b6a9c081fa3e545573152a788d061a0a0ba57df7251cc0f4f75225fc93e7
+md5: f9fe2984587fa8235a6af6004760cd18
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: LGPL-2.0-or-later
+license_family: LGPL
+size: 102835
+timestamp: 1786118485753
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.4.1-pyhcf101f3_0.conda
+sha256: 307dd6ec90140c3cf4171071b0e5e870abec314f4565c1edd5bc433e942cdcc0
+md5: e652ac7756069c456d0da2a922cd7df5
+depends:
+- python >=3.10
+- hyperframe >=6.1,<7
+- hpack >=4.2,<5
+- python
+license: MIT
+license_family: MIT
+size: 100789
+timestamp: 1785796355216
+- conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.16.0-nompi_py312hfaa9938_104.conda
+sha256: 64e1d13bc0ec29fa416aeefac77283eea349f3ed2acfcfc513f0cacd30fbcf6d
+md5: 9ca94eb30bd0938240f32b6e6398b862
+depends:
+- __glibc >=2.17,<3.0.a0
+- cached-property
+- hdf5 >=1.14.6,<1.14.7.0a0
+- libgcc >=15
+- numpy >=1.25,<3
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: BSD-3-Clause
+license_family: BSD
+size: 1353159
+timestamp: 1787108753979
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-14.4.0-ha770c72_1.conda
+sha256: 12b371fad335d0c27de968140088cc678233d7060c2743baf9cb687a9fa975a7
+md5: d5c10e05d7135fca0731173c288bfff5
+depends:
+- libharfbuzz-devel 14.4.0 h23af247_1
+license: MIT
+license_family: MIT
+size: 11107
+timestamp: 1788405531557
+- conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_110.conda
+sha256: ac57ce3abbda2a82d6192bc36fbd7fe96e867d84c999ef81a3da034dfd01a995
+md5: 9c6e11a83468e1d5decae516077a73fb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libaec >=1.1.5,<2.0a0
+- libcurl >=8.20.0,<9.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.6,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 3721555
+timestamp: 1780581675871
+- conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
+sha256: fdcea5d7cb314485d3907192ef024c704311548c5b0cbeb390cd1951051e29d2
+md5: b395909221b9bd1df066e5930e18855b
+depends:
+- python >=3.10
+license: MIT
+license_family: MIT
+size: 32884
+timestamp: 1782283986153
+- conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
+sha256: 77af6f5fe8b62ca07d09ac60127a30d9069fdc3c68d6b256754d0ffb1f7779f8
+md5: 8e6923fc12f1fe8f8c4e5c9f343256ac
+depends:
+- python >=3.9
+license: MIT
+license_family: MIT
+size: 17397
+timestamp: 1737618427549
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+md5: 72a381cbad04f24b1c2a43ef707f45b4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 14459115
+timestamp: 1786545741408
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.19-pyhcf101f3_0.conda
+sha256: 1c35a59c1545ad0fdaddf1fbde7bcfa6ef41a8d68c3a2b0b4a291be00676163e
+md5: a39ae05027e9b707742e41b30d296b75
+depends:
+- python >=3.10
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 177433
+timestamp: 1787059857580
+- conda: https://conda.anaconda.org/conda-forge/linux-64/igraph-1.0.1-hfe3e89f_0.conda
+sha256: 5d4619b4730184185bf93f77df00d740480805e059d3a03f11d8ebb03e5e5e6d
+md5: b4a5bf8c98b19a4666597d30addbd675
+depends:
+- __glibc >=2.17,<3.0.a0
+- arpack >=3.9.1,<3.10.0a0 nompi_*
+- glpk >=5.0,<6.0a0
+- gmp >=6.3.0,<7.0a0
+- libblas >=3.9.0,<4.0a0
+- libgcc >=14
+- liblapack >=3.9.0,<4.0a0
+- libstdcxx >=14
+- libxml2
+- libxml2-16 >=2.14.6
+- libxml2-devel
+license: GPL-2.0-or-later
+license_family: GPL
+size: 1665781
+timestamp: 1766862001031
+- conda: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2026.8.16-py312h3d3c6f4_0.conda
+sha256: 52a761b5b9fbd73539ab645277c10956d6380029f9a72cb4b168613a456ecfa3
+md5: 73e40d83cd7352a74fab99cd08ccca5b
+depends:
+- __glibc >=2.17,<3.0.a0
+- blosc >=1.21.6,<2.0a0
+- brunsli >=0.1,<1.0a0
+- bzip2 >=1.0.8,<2.0a0
+- c-blosc2 >=3.3.2,<3.4.0a0
+- charls >=2.4.4,<2.5.0a0
+- giflib >=5.2.2,<5.3.0a0
+- jxrlib >=1.1,<1.2.0a0
+- lcms2 >=2.19.1,<3.0a0
+- lerc >=4.2.0,<5.0a0
+- libaec >=1.1.5,<2.0a0
+- libavif16 >=1.4.2,<2.0a0
+- libbrotlicommon >=1.2.0,<1.3.0a0
+- libbrotlidec >=1.2.0,<1.3.0a0
+- libbrotlienc >=1.2.0,<1.3.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=15
+- libjpeg-turbo >=3.2.0,<4.0a0
+- libjxl >=0.12.0,<0.13.0a0
+- liblzma >=5.8.3,<6.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=15
+- libtiff >=4.7.2,<4.8.0a0
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- libzopfli >=1.0.3,<1.1.0a0
+- lz4-c >=1.10.0,<1.11.0a0
+- numpy >=1.25,<3
+- openjpeg >=2.5.4,<3.0a0
+- openjph >=0.31.0,<0.32.0a0
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+- snappy >=1.2.2,<1.3.0a0
+- zfp >=1.0.1,<2.0a0
+- zlib-ng >=2.3.3,<2.4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 2285384
+timestamp: 1786846577148
+- conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
+sha256: 8ef69fa00c68fad34a3b7b260ea774fda9bd9274fd706d3baffb9519fd0063fe
+md5: b5577bc2212219566578fd5af9993af6
+depends:
+- numpy
+- pillow >=8.3.2
+- python >=3.9
+license: BSD-2-Clause
+license_family: BSD
+size: 293226
+timestamp: 1738273949742
+- conda: https://conda.anaconda.org/conda-forge/linux-64/imath-3.2.2-hde8ca8f_0.conda
+sha256: 43f30e6fd8cbe1fef59da760d1847c9ceff3fb69ceee7fd4a34538b0927959dd
+md5: c427448c6f3972c76e8a4474e0fe367b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 160289
+timestamp: 1759983212466
+- conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.1-pyhcf101f3_0.conda
+sha256: 95a074a7d3f58b3494c068d4789c364dcb591c56b70ca6b12f149a540f9aeea4
+md5: 77ec68e0aa61c3fff9ecbf840f93d64e
+depends:
+- python >=3.10
+- zipp >=3.20
+- python
+license: Apache-2.0
+license_family: APACHE
+size: 34920
+timestamp: 1787943971257
+- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.10.0-hb700be7_0.conda
+sha256: bc231d69eb6663db0e09738fb916c5e5507147cf1ac60f364f964004e0b29bab
+md5: 10909406c1b0e4b57f9f4f0eb0999af8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 1013714
+timestamp: 1774422680665
+- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-26.1.6-hecca717_0.conda
+sha256: 7cbd7fda22db70c64af64c9173434a4ede58e4f220bda52a044e469aa94c65cb
+md5: aaf7c3db8c7c4533deb5449d3ba1c51f
+depends:
+- __glibc >=2.17,<3.0.a0
+- intel-gmmlib >=22.10.0,<23.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libva >=2.23.0,<3.0a0
+license: MIT
+license_family: MIT
+size: 8782375
+timestamp: 1776080148587
+- conda: https://conda.anaconda.org/conda-forge/noarch/interface_meta-1.3.0-pyhd8ed1ab_1.conda
+sha256: cdd4377e9565f383e3e69f26b43fc1abc892fda591fa724af508e498c2dc0859
+md5: 97f07ae607e01877f0454fce4c833e40
+depends:
+- python >=3.9
+license: MIT
+license_family: MIT
+size: 18422
+timestamp: 1734284523576
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
+md5: 04558c96691bed63104678757beb4f8d
+depends:
+- markupsafe >=2.0
+- python >=3.10
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 120685
+timestamp: 1764517220861
+- conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.6.0-pyhcf101f3_0.conda
+sha256: 96b76ace583404ce4fbc234baa6cdb3de485887913104d4ac51994f9b6656696
+md5: 4ebc70ef1af2e21cdc8edb1bfa1ec28d
+depends:
+- python >=3.10
+- cloudpickle >=3.0
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 228858
+timestamp: 1788177170105
+- conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
+sha256: 09e706cb388d3ea977fabcee8e28384bdaad8ce1fc49340df5f868a2bd95a7da
+md5: 38f5dbc9ac808e31c00650f7be1db93f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: MIT
+license_family: MIT
+size: 82709
+timestamp: 1726487116178
+- conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
+sha256: 2057ca87b313bde5b74b93b0e696f8faab69acd4cb0edebb78469f3f388040c0
+md5: 5aeabe88534ea4169d4c49998f293d6c
+depends:
+- libgcc-ng >=12
+license: BSD-2-Clause
+license_family: BSD
+size: 239104
+timestamp: 1703333860145
+- conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+sha256: dd053c96dcb0dcfd59422aefea9d2fe937a190167f34fba7893ec1e10a7e8963
+md5: ba55d1b89fd7775e67de8291029b4059
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: LGPL-2.1-or-later
+size: 135295
+timestamp: 1786739238128
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.1-py312h9be0db6_1.conda
+sha256: 608716113cb671415a038654e2bc55c2372c8817c24c0a5043323fd7c06b86f3
+md5: 231fede9051444ed7d243f78f3cb4a8f
+depends:
+- python
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=15
+- libgcc >=15
+- python_abi 3.12.* *_cp312
+license: BSD-3-Clause
+size: 75215
+timestamp: 1788505643992
+- conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+sha256: 2a5c38c85e63df84c4e69ee71439841ce570d259ae3060627bb9a49a938d66f4
+md5: 53318d715316929a574f83591308b1f8
+depends:
+- __glibc >=2.17,<3.0.a0
+- keyutils >=1.6.3,<2.0a0
+- libedit >=3.1.20250104,<3.2.0a0
+- libedit >=3.1.20250104,<4.0a0
+- libgcc >=15
+- libstdcxx >=15
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 1394333
+timestamp: 1786762112514
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
+md5: a8832b479f93521a9e7b5b743803be51
+depends:
+- libgcc-ng >=12
+license: LGPL-2.0-only
+license_family: LGPL
+size: 508258
+timestamp: 1664996250081
+- conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
+sha256: 1a88069ac61d2756ccaf26a6c206ab4d56610fb054bd2fffb5df4cd0744ab78e
+md5: 75932da6f03a6bef32b70a51e991f6eb
+depends:
+- packaging
+- python >=3.10
+license: BSD-3-Clause
+license_family: BSD
+size: 14883
+timestamp: 1772817374026
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h9073bf1_2.conda
+sha256: 8cdec1ff3f276cd2069dca0dae4f45f3dc5c224e2d72daef78227832938467a6
+md5: b68c7304d2edb0f1a5bdfb875094d603
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libjpeg-turbo >=3.2.0,<4.0a0
+- libtiff >=4.7.2,<4.8.0a0
+license: MIT
+license_family: MIT
+size: 253830
+timestamp: 1788155917881
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+md5: 449500f2c089da11c40f5c21312e3e07
+depends:
+- __glibc >=2.17,<3.0.a0
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+size: 745303
+timestamp: 1784214507189
+- conda: https://conda.anaconda.org/conda-forge/noarch/legacy-api-wrap-1.5-pyhd8ed1ab_0.conda
+sha256: 680ae16bf64fc2023601415b5841f297baa269714ee14fff452941d77b73112c
+md5: 0f67063cc1769bcb0e4e5ecbca22f8b6
+depends:
+- python >=3.10
+license: MPL-2.0
+license_family: MOZILLA
+size: 15868
+timestamp: 1762187673390
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+sha256: bf9fdebf55d8bc99d83531cdffda00703f4dc5f93a1a956768c147362c72feda
+md5: fb9d356b1a57d6d54768be7ebd5fce09
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: Apache
+size: 271158
+timestamp: 1785036167977
+- conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.33.1-h7148c6a_0.conda
+sha256: ae6bc49a784c442b4cf5b1306a342a4f85667b2f489509c01bb77edec0f9e0f3
+md5: 88ec7b59e2bff6caf5b517f73e7ce853
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+license: MIT
+license_family: MIT
+size: 780520
+timestamp: 1788366449509
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h0dc7533_2.conda
+sha256: 7bb3d495411b7059e85225aae500d84e7846a4bb02ebd77e4450200b20c180f0
+md5: 6983bfe8e09992014b9cf393769c7a84
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+constrains:
+- abseil-cpp =20260526.0
+- libabseil-static =20260526.0=cxx17*
+license: Apache-2.0
+license_family: Apache
+size: 1436888
+timestamp: 1787217011773
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.5-h088129d_0.conda
+sha256: 822e4ae421a7e9c04e841323526321185f6659222325e1a9aedec811c686e688
+md5: 86f7414544ae606282352fa1e116b41f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: BSD-2-Clause
+license_family: BSD
+size: 36544
+timestamp: 1769221884824
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.9-gpl_h3152399_101.conda
+sha256: bfae027a67d02325cd6b75edd60beb67cf24483af9df0ae9ef74d4438e41c806
+md5: 680520cff78a974d564cd99cdf5ec0b5
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=15
+- liblzma >=5.8.3,<6.0a0
+- libxml2
+- libxml2-16 >=2.15.3
+- libzlib >=1.3.2,<2.0a0
+- lz4-c >=1.10.0,<1.11.0a0
+- lzo >=2.10,<3.0a0
+- openssl >=3.5.7,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 875346
+timestamp: 1787292369121
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-25.0.0-hcc2f0d9_4_cpu.conda
+build_number: 4
+sha256: b3b92d94fa20d1d195de702c4b61cd0c3438d26672cbaf6ebbf021114a840a77
+md5: c344b5608c65a09b341f2e784efb4422
+depends:
+- __glibc >=2.17,<3.0.a0
+- aws-crt-cpp >=0.40.1,<0.40.2.0a0
+- aws-sdk-cpp >=1.11.833,<1.11.834.0a0
+- azure-core-cpp >=1.16.3,<1.16.4.0a0
+- azure-identity-cpp >=1.13.3,<1.13.4.0a0
+- azure-storage-blobs-cpp >=12.18.0,<12.18.1.0a0
+- azure-storage-files-datalake-cpp >=12.16.0,<12.16.1.0a0
+- bzip2 >=1.0.8,<2.0a0
+- glog >=0.7.1,<0.8.0a0
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libbrotlidec >=1.2.0,<1.3.0a0
+- libbrotlienc >=1.2.0,<1.3.0a0
+- libgcc >=14
+- libgoogle-cloud >=3.8.0,<3.9.0a0
+- libgoogle-cloud-storage >=3.8.0,<3.9.0a0
+- libopentelemetry-cpp >=1.27.0,<1.28.0a0
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+- lz4-c >=1.10.0,<1.11.0a0
+- orc >=2.3.1,<2.3.2.0a0
+- snappy >=1.2.2,<1.3.0a0
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- apache-arrow-proc =*=cpu
+- arrow-cpp <0.0a0
+- parquet-cpp <0.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 6598422
+timestamp: 1786315080658
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-25.0.0-h635bf11_4_cpu.conda
+build_number: 4
+sha256: 886631b6e32f62e04cc314462c0fbbf9d461cfb6625d2384ae0f36b5a8a72890
+md5: 64fad2fca810b34f5bbc9738a6fb298f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libarrow 25.0.0 hcc2f0d9_4_cpu
+- libarrow-compute 25.0.0 h53684a4_4_cpu
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: APACHE
+size: 590543
+timestamp: 1786315249993
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-25.0.0-h53684a4_4_cpu.conda
+build_number: 4
+sha256: ad642502977edceeb4ca385e42f085fb4391c409d8d098866bc4a5e3fda7a04a
+md5: 05f6b378ae80d2d06e35dc794412da3a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libarrow 25.0.0 hcc2f0d9_4_cpu
+- libgcc >=14
+- libre2-11 >=2025.11.5
+- libstdcxx >=14
+- libutf8proc >=2.11.3,<2.12.0a0
+- re2
+license: Apache-2.0
+license_family: APACHE
+size: 2974934
+timestamp: 1786315141259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-25.0.0-h635bf11_4_cpu.conda
+build_number: 4
+sha256: 6715d36e6aaf00986876e67e97ae8e9b60afb2a7f52ab79b89543c37cd914e28
+md5: 26f7b996f0674217f78d5c6432445b71
+depends:
+- __glibc >=2.17,<3.0.a0
+- libarrow 25.0.0 hcc2f0d9_4_cpu
+- libarrow-acero 25.0.0 h635bf11_4_cpu
+- libarrow-compute 25.0.0 h53684a4_4_cpu
+- libgcc >=14
+- libparquet 25.0.0 h7376487_4_cpu
+- libstdcxx >=14
+license: Apache-2.0
+license_family: APACHE
+size: 591131
+timestamp: 1786315326056
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-25.0.0-h66fbfdd_4_cpu.conda
+build_number: 4
+sha256: 7478e785ad4b7aee72e685921d849b3fb11b0c477dfea76d9e861ee5056b35a6
+md5: 287c5915a8b8bf79613840e0df9dc7b7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libarrow 25.0.0 hcc2f0d9_4_cpu
+- libarrow-acero 25.0.0 h635bf11_4_cpu
+- libarrow-dataset 25.0.0 h635bf11_4_cpu
+- libgcc >=14
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libstdcxx >=14
+license: Apache-2.0
+license_family: APACHE
+size: 500255
+timestamp: 1786315353425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.5-h434b012_0.conda
+sha256: 24d4b59a0267e1c159c3af82df106b42faeefccceba3c489044c93abf113c503
+md5: c1cb4d6e8a6e3f724740dee5346fc8b4
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libzlib >=1.3.2,<2.0a0
+- fribidi >=1.0.16,<2.0a0
+- fontconfig >=2.18.1,<3.0a0
+- fonts-conda-ecosystem
+- libiconv >=1.18,<2.0a0
+- harfbuzz >=14.2.1
+license: ISC
+size: 154964
+timestamp: 1782298715788
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.4.2-h3ef1eba_4.conda
+sha256: f4c7dbdff93bc62e4aa4a94635c4a139cd4b1e8deb753af5892a8f1ee6456b4d
+md5: 2326d9fe25838dddac1f3876aa7ff878
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- rav1e >=0.8.1,<0.9.0a0
+- aom >=3.14.1,<3.15.0a0
+- libdav1d7 >=1.5.4
+- svt-av1 >=4.2.0,<4.2.1.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 168234
+timestamp: 1788391245817
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-10_h5875eb1_mkl.conda
+build_number: 10
+sha256: 15b4c82e8c1d9f4a609890c8f5409fa42230da29cd91affdeb4d41906549aa1d
+md5: fe1a5ccbcba308212c58f9a8059c4b5a
+depends:
+- mkl >=2026.1.0,<2027.0a0
+constrains:
+- blas 2.310   mkl
+- libcblas   3.11.0   10*_mkl
+- liblapack  3.11.0   10*_mkl
+- liblapacke 3.11.0   10*_mkl
+track_features:
+- blas_mkl
+- blas_mkl_2
+license: BSD-3-Clause
+license_family: BSD
+size: 18477
+timestamp: 1788077004663
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+md5: df210655e30a05e3b069c91b7aaddd2d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: MIT
+size: 80561
+timestamp: 1788480364653
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+md5: 0cfd601eb03cca403dcc248844787486
+depends:
+- __glibc >=2.17,<3.0.a0
+- libbrotlicommon 1.2.0 h39a168f_4
+- libgcc >=15
+license: MIT
+size: 34739
+timestamp: 1788480374261
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+md5: 4136f6e4ef4835cc7df39a707cbd511c
+depends:
+- __glibc >=2.17,<3.0.a0
+- libbrotlicommon 1.2.0 h39a168f_4
+- libgcc >=15
+license: MIT
+size: 298134
+timestamp: 1788480383223
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.78-h084b8d7_1.conda
+sha256: 8cb25174d6b6fac95d31e86cfe41faffc8ee9dacbf2bfd22e6c23377e8f338c1
+md5: 5db514adf5f843126ff846d1510f22a4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 124306
+timestamp: 1786025967663
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-10_hfef963f_mkl.conda
+build_number: 10
+sha256: 77d5ffec523f85f627df251aae2eefa23518d4eec36dd045e0d40dddc80d69cf
+md5: 5447c2bbf73e2e83d14cfa43717f0c14
+depends:
+- libblas 3.11.0 10_h5875eb1_mkl
+constrains:
+- blas 2.310   mkl
+- liblapack  3.11.0   10*_mkl
+- liblapacke 3.11.0   10*_mkl
+track_features:
+- blas_mkl
+license: BSD-3-Clause
+license_family: BSD
+size: 18127
+timestamp: 1788077011041
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp23.1-23.1.0-default_h0acdd01_1.conda
+sha256: ff0507777b9d5ff5678466516d2f1793361ecef541114fb6f3cabb91fc7d5b3c
+md5: d3ba2947f7d7cdd7c4eb73b206de330b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=15
+- libgcc >=15
+- libxml2
+- libxml2-16 >=2.15.3
+- zstd >=1.5.7,<1.6.0a0
+- libzlib >=1.3.2,<2.0a0
+- libllvm23 >=23.1.0,<23.2.0a0
+license: Apache-2.0 WITH LLVM-exception
+license_family: APACHE
+size: 25353391
+timestamp: 1788037800581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-23.1.0-default_h7855034_1.conda
+sha256: 1c7589a69833294ab79e5b239d4d70c8c6af68b745a5c17344319d088d884bb0
+md5: 6afb92887568acc8f18281c57c92c28b
+depends:
+- libclang-cpp23.1 ==23.1.0 default_h0acdd01_1
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=15
+- libgcc >=15
+- libxml2
+- libxml2-16 >=2.15.3
+- zstd >=1.5.7,<1.6.0a0
+- libzlib >=1.3.2,<2.0a0
+- libllvm23 >=23.1.0,<23.2.0a0
+license: Apache-2.0 WITH LLVM-exception
+license_family: APACHE
+size: 15442245
+timestamp: 1788037800581
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+md5: c965a5aa0d5c1c37ffc62dff36e28400
+depends:
+- libgcc-ng >=9.4.0
+- libstdcxx-ng >=9.4.0
+license: BSD-3-Clause
+license_family: BSD
+size: 20440
+timestamp: 1633683576494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
+md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.1,<2.0a0
+license: Apache-2.0
+license_family: Apache
+size: 4518030
+timestamp: 1770902209173
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.22.0-ha042cf0_0.conda
+sha256: 483b7eb97f56fbb3a9cb7190d33012dfa0a5aaed99ede61465563cd97dd82504
+md5: e617deee7af8eb0c04f6296d12b54157
+depends:
+- __glibc >=2.17,<3.0.a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=15
+- libnghttp2 >=1.68.1,<2.0a0
+- libpsl >=0.23.1,<0.24.0a0
+- libssh2 >=1.11.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.8,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: curl
+license_family: MIT
+size: 499651
+timestamp: 1788340719230
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdav1d7-1.5.4-hebe6cf0_4.conda
+sha256: 9d3d31b9549f76ab61e2678a22566e4342842f388ec6df4ac10aea3ae3526697
+md5: ad38caba8fd619ac5e6d5fef0a6678cd
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: BSD-2-Clause
+license_family: BSD
+size: 765022
+timestamp: 1788366542408
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
+md5: 40f9b31aa9cf007789867df0decd0492
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 73710
+timestamp: 1785908694612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdovi-3.4.0-ha23c83e_0.conda
+sha256: cea351b57c30d70e288b53ea69a1dcf6b750992f5d7717a7fc364072fa1209e7
+md5: 4377d220f09344452b227d699cacce4f
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+constrains:
+- __glibc >=2.17
+license: MIT
+license_family: MIT
+size: 404998
+timestamp: 1784281566921
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.129-h7cc23a3_0.conda
+sha256: ea46b0ca0fa16af1f8b329b740e6cd8b4577c5378fa8717b28a885f70668633d
+md5: 64cc91512b6278c315349dc13c53f680
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libpciaccess >=0.19,<0.20.0a0
+license: MIT
+license_family: MIT
+size: 313461
+timestamp: 1786684701973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
+md5: 50708d3b951d0f8e2d7f2df5b5edc040
+depends:
+- ncurses
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- ncurses >=6.6,<7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 135098
+timestamp: 1786616658086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_5.conda
+sha256: 13d3fde9c1dcf254968cc70652222a43f25d04e69555ccf855553110e753288e
+md5: 3a1b41c4591a0a1734382af3e2b8bc08
+depends:
+- __glibc >=2.17,<3.0.a0
+- libglvnd 1.7.0 ha4b6fd6_5
+license: LicenseRef-libglvnd
+size: 46694
+timestamp: 1787310030923
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-devel-1.7.0-ha4b6fd6_5.conda
+sha256: fd2794bbcff7e692fb476c17886702702893d074071d429217bad7cfb072abfd
+md5: 577800fc8c9d8b7d9727246bbfde704e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libegl 1.7.0 ha4b6fd6_5
+- libgl-devel 1.7.0 ha4b6fd6_5
+- xorg-libx11
+license: LicenseRef-libglvnd
+size: 31242
+timestamp: 1787310065866
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+md5: 7bc31538d6e3fb349e897353969237ec
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: BSD-2-Clause OR GPL-2.0-or-later
+license_family: GPL
+size: 43220
+timestamp: 1785917328200
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+depends:
+- libgcc-ng >=12
+- openssl >=3.1.1,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 427426
+timestamp: 1685725977222
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+md5: b24d3c612f71e7aa74158d92106318b2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+size: 77856
+timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+md5: 6525a0b06aa4fd390795f0740636a9dd
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: MIT
+license_family: MIT
+size: 68004
+timestamp: 1787753412298
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+sha256: e755e234236bdda3d265ae82e5b0581d259a9279e3e5b31d745dc43251ad64fb
+md5: 47595b9d53054907a00d95e4d47af1d6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libiconv >=1.18,<2.0a0
+- libogg >=1.3.5,<1.4.0a0
+- libstdcxx >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 424563
+timestamp: 1764526740626
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+sha256: fb12ecb46c30d18d928c0e8fc346ab13b5f6fc8a9cacae4f2f4bb188782586f5
+md5: f8054e759d0ddddaf34a5c8fedc900a1
+depends:
+- libfreetype6 >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 8407
+timestamp: 1786641007099
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+sha256: ec607dd5445dd17ff6bf8b7fe6832e5504c226dd91d3aaea7ba83569808b0ce4
+md5: b72a266a9317036fd0464cb98b027cd0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libpng >=1.6.58,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- freetype >=2.14.3
+license: GPL-2.0-only OR FTL
+size: 387671
+timestamp: 1786641006460
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+md5: cba14d01083fc62ffd32c24d7d390633
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+constrains:
+- libgcc-ng ==16.2.0=*_4
+- libgomp 16.2.0 he0feb66_4
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 1058083
+timestamp: 1787618680111
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
+sha256: d8e66c14e23f2b3c70410cff5979d9d357e6edfb990b28d8e630852f4d395629
+md5: b3e52878163a841f6fb951989cc0b217
+depends:
+- libgcc 16.2.0 ha9f2e26_4
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28403
+timestamp: 1787618684957
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.2-hd345f60_2.conda
+sha256: 0570dfc66c02819c9deb53f20e8da05c21bfeb36e52cebffe375c11e701a9d37
+md5: c59f9831713acf3caa0a739407b335bc
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- __glibc >=2.17,<3.0.a0
+- libdeflate >=1.25,<1.26.0a0
+- blosc >=1.21.6,<2.0a0
+- xerces-c >=3.3.0,<3.4.0a0
+- libiconv >=1.18,<2.0a0
+- geos >=3.14.1,<3.14.2.0a0
+- openssl >=3.5.7,<4.0a0
+- proj >=9.8.1,<9.9.0a0
+- json-c >=0.18,<0.19.0a0
+- giflib >=5.2.2,<5.3.0a0
+- libzlib >=1.3.2,<2.0a0
+- libpng >=1.6.58,<1.7.0a0
+- liblzma >=5.8.3,<6.0a0
+- libexpat >=2.8.1,<3.0a0
+- zstd >=1.5.7,<1.6.0a0
+- libsqlite >=3.53.4,<4.0a0
+- libjpeg-turbo >=3.2.0,<4.0a0
+- libwebp-base >=1.6.0,<2.0a0
+- libarchive >=3.8.9,<3.9.0a0
+- pcre2 >=10.47,<10.48.0a0
+- lerc >=4.2.0,<5.0a0
+- libspatialite >=5.1.0,<5.2.0a0
+- lz4-c >=1.10.0,<1.11.0a0
+- libcurl >=8.21.0,<9.0a0
+- libkml >=1.3.0,<1.4.0a0
+- libxml2
+- libxml2-16 >=2.14.6
+- libjxl >=0.12.0,<0.13.0a0
+- muparser >=2.3.5,<2.4.0a0
+constrains:
+- libgdal 3.13.2.*
+license: MIT
+license_family: MIT
+size: 15024114
+timestamp: 1786285583752
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
+sha256: 7653be4d88a4d74676c38dd892914d027dcecc0c65c406be772d31cb641f8cfd
+md5: 5e92b8413fd1c8f8f3006f4661b12def
+depends:
+- libgfortran5 16.2.0 h6b99dfc_4
+constrains:
+- libgfortran-ng ==16.2.0=*_4
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28377
+timestamp: 1787618711732
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
+sha256: a5510cbcea3b9e9ab24b336429de997fa727af1dba323031500a962a20e38600
+md5: c22348a769bb072b6184eb6f7f05e4f2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=16.2.0
+constrains:
+- libgfortran 16.2.0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 2526008
+timestamp: 1787618692926
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_5.conda
+sha256: 7b2e7e31e8a4f5a01c45ecadcd8aa68c8f733b035240bc7ba9881835ef4bf7b4
+md5: 81141db127a106eb5a91df69a29c9918
+depends:
+- __glibc >=2.17,<3.0.a0
+- libglvnd 1.7.0 ha4b6fd6_5
+- libglx 1.7.0 ha4b6fd6_5
+license: LicenseRef-libglvnd
+size: 131988
+timestamp: 1787310049847
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_5.conda
+sha256: 3bebdbeb3ce451287794dddd5cc4d7f4970aac200b2fb797f0d17ac727a71cb7
+md5: f5f7fc038c611a25b22758c0a40d25c9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgl 1.7.0 ha4b6fd6_5
+- libglx-devel 1.7.0 ha4b6fd6_5
+license: LicenseRef-libglvnd
+size: 116212
+timestamp: 1787310061570
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-he503a2a_2.conda
+sha256: af6c14f387f810c5df491b328ae955329596d3bc73b1e2e091ab5adb46a10759
+md5: 533d342dedadf134c67760ce6fc5b748
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- pcre2 >=10.47,<10.48.0a0
+- libzlib >=1.3.2,<2.0a0
+- libiconv >=1.18,<2.0a0
+- libffi >=3.7.0,<3.8.0a0
+constrains:
+- glib >2.66
+license: LGPL-2.1-or-later
+size: 4758097
+timestamp: 1787884091247
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_5.conda
+sha256: 6eb77601a44b78c4631d886d54ef54f321c2bdc69fdefc4065a1e0491f030c76
+md5: cfcf11edcfd4acf0094771a9c3b8587f
+depends:
+- __glibc >=2.17,<3.0.a0
+license: LicenseRef-libglvnd
+size: 133827
+timestamp: 1787310026653
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_5.conda
+sha256: d1f0d51aea6bcc5d915969cbed32e72a8ed6a95931b87357ef8d0866573688c4
+md5: 614e10aae180f87b84f0d1ca8ceb7d9e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libglvnd 1.7.0 ha4b6fd6_5
+- xorg-libx11 >=1.8.13,<2.0a0
+license: LicenseRef-libglvnd
+size: 79834
+timestamp: 1787310042550
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-devel-1.7.0-ha4b6fd6_5.conda
+sha256: aff3841e3404d78e1887fef988ca4842930c577399d566fa0980808756b1df51
+md5: fb00b4fb800f2d431303a5c1625ef9d0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libglx 1.7.0 ha4b6fd6_5
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-xorgproto
+license: LicenseRef-libglvnd
+size: 27698
+timestamp: 1787310053582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-3.8.0-hbc29df5_0.conda
+sha256: 46126b858d173d6808262e39e3a8aa39946d39aebb5ffb720984dc44f74feafe
+md5: 60ff8935e16bf2fd302289ec4f129df8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libcurl >=8.21.0,<9.0a0
+- libgcc >=14
+- libgrpc >=1.82.1,<1.83.0a0
+- libopentelemetry-cpp >=1.27.0,<1.28.0a0
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libstdcxx >=14
+- openssl >=3.5.7,<4.0a0
+constrains:
+- libgoogle-cloud 3.8.0 *_0
+license: Apache-2.0
+license_family: Apache
+size: 2663465
+timestamp: 1786226759530
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-3.8.0-hdbdcf42_0.conda
+sha256: 03437ce50129f9ca82a0400b7722cd2dd3ee3bfa50dcb557657f55a7de76ab6f
+md5: 84a8d5a661792da2127ab908b5ae83ef
+depends:
+- __glibc >=2.17,<3.0.a0
+- libabseil
+- libcrc32c >=1.1.2,<1.2.0a0
+- libcurl
+- libgcc >=14
+- libgoogle-cloud 3.8.0 hbc29df5_0
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+- openssl
+license: Apache-2.0
+license_family: Apache
+size: 810573
+timestamp: 1786226867433
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.82.1-h792040b_0.conda
+sha256: 1e657c1b802c111178bc1845fe06488db5f69a85e34e970ce0989810aa562d45
+md5: aa4571fc3bcf18ad12370429aa991223
+depends:
+- __glibc >=2.17,<3.0.a0
+- c-ares >=1.34.6,<2.0a0
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libgcc >=14
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libre2-11 >=2025.11.5
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+- re2
+constrains:
+- grpc-cpp =1.82.1
+license: Apache-2.0
+license_family: APACHE
+size: 6957755
+timestamp: 1783588701960
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.4.0-h23af247_1.conda
+sha256: 979b14ba13054aab9e90363809aac470a58b7c37203c330216327356a98c8f60
+md5: c44470b6bfa6a582cb4dd42cbda3401e
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=15
+- libglib >=2.88.3,<3.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=15
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 1382623
+timestamp: 1788405508587
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-devel-14.4.0-h23af247_1.conda
+sha256: 11f08038c165e354c2a7064ce6bcb28dad2668b330931572666f418e2a8f623c
+md5: 148cd995f5ba8af22412a4258abc2f94
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- freetype
+- graphite2 >=1.3.15,<2.0a0
+- icu >=78.3,<79.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=15
+- libglib >=2.88.3,<3.0a0
+- libharfbuzz 14.4.0 h23af247_1
+- libpng >=1.6.58,<1.7.0a0
+- libstdcxx >=15
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 2144076
+timestamp: 1788405523805
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.13.0-default_he001693_1000.conda
+sha256: 5041d295813dfb84652557839825880aae296222ab725972285c5abe3b6e4288
+md5: c197985b58bc813d26b42881f0021c82
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libxml2
+- libxml2-16 >=2.14.6
+license: BSD-3-Clause
+license_family: BSD
+size: 2436378
+timestamp: 1770953868164
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.4.0-h57c4cff_1.conda
+sha256: 23c7cf726b883f5e7c1bfa6bf24bceafa8be87245a7690e0b5c974eb320a9e83
+md5: d58bfbaaf51ed85771eae92c2e7f5816
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+license: Apache-2.0 OR BSD-3-Clause
+size: 1454025
+timestamp: 1787282422734
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+md5: f92233bf33e24a25668bb2119e2c51f9
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: LGPL-2.1-only
+size: 789471
+timestamp: 1787033836207
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+sha256: bba8538e6538ed58a8479b332337b96986561f975d06cfa2039a016c2d246ee4
+md5: 898d1c9793eaa52efc4727bd84d2e39a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- jpeg <0.0.0a
+license: IJG AND BSD-3-Clause AND Zlib
+size: 650434
+timestamp: 1785896381946
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.12.0-heb2dce7_2.conda
+sha256: 965e59ea776344e93a416f7e0ba309810470a61c0e0c65f1eb90be0e808d7e9c
+md5: 485788d339785bac87fe86315b4a0627
+depends:
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=15
+- libhwy >=1.4.0,<1.5.0a0
+- libbrotlienc >=1.2.0,<1.3.0a0
+- libbrotlidec >=1.2.0,<1.3.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1886013
+timestamp: 1786691380980
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-haa4a5bd_1023.conda
+sha256: f6348ac9cebbc03f765ea6d2da88d57d19531585c8f3a963b98635b208e8bef1
+md5: 953b7cca897e21215302dbfe2af5cd0c
+depends:
+- __glibc >=2.17,<3.0.a0
+- libexpat >=2.7.5,<3.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+- uriparser >=0.9.8,<1.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 412514
+timestamp: 1777026799177
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-10_h5e43f62_mkl.conda
+build_number: 10
+sha256: 182f78268834055d24a14f1cc233ef5df0e94d7ff66b0c4e5d4e9df8596c142d
+md5: 25dcf7345bd6c4ec965e1e5b9e105233
+depends:
+- libblas 3.11.0 10_h5875eb1_mkl
+constrains:
+- blas 2.310   mkl
+- libcblas   3.11.0   10*_mkl
+- liblapacke 3.11.0   10*_mkl
+track_features:
+- blas_mkl
+license: BSD-3-Clause
+license_family: BSD
+size: 18134
+timestamp: 1788077018484
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.11.0-10_hdba1596_mkl.conda
+build_number: 10
+sha256: d4da1fcd4ac12cc69ccd7ee5de93432599f647d146e67b655e71385fad48bf90
+md5: ec3a7867279c8eb4dbc846a27010946d
+depends:
+- libblas 3.11.0 10_h5875eb1_mkl
+- libcblas 3.11.0 10_hfef963f_mkl
+- liblapack 3.11.0 10_h5e43f62_mkl
+constrains:
+- blas 2.310   mkl
+track_features:
+- blas_mkl
+license: BSD-3-Clause
+license_family: BSD
+size: 18149
+timestamp: 1788077024933
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm23-23.1.0-h474f4eb_0.conda
+sha256: 50b31f6c51afe7df0639acf5dde8acf3f4f0dc9f644ab9842b717ae798507d68
+md5: 3b8c8325547a4fd8c51649ef7dfab688
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+- libxml2
+- libxml2-16 >=2.15.3
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: Apache-2.0 WITH LLVM-exception
+license_family: Apache
+size: 45046595
+timestamp: 1787716721647
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+size: 112995
+timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+md5: 75d211f04ac87506f1f43420712a69fe
+depends:
+- __glibc >=2.17,<3.0.a0
+- c-ares >=1.34.8,<2.0a0
+- libev >=4.33,<4.34.0a0
+- libev >=4.33,<5.0a0
+- libgcc >=15
+- libstdcxx >=15
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+license: MIT
+license_family: MIT
+size: 649974
+timestamp: 1787177490105
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+md5: d864d34357c3b65a4b731f78c0801dc4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: LGPL-2.1-only
+license_family: GPL
+size: 33731
+timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
+sha256: 3b3f19ced060013c2dd99d9d46403be6d319d4601814c772a3472fe2955612b0
+md5: 7c7927b404672409d9917d49bff5f2d6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: LGPL-2.1-or-later
+size: 33418
+timestamp: 1734670021371
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+sha256: ffb066ddf2e76953f92e06677021c73c85536098f1c21fcd15360dbc859e22e4
+md5: 68e52064ed3897463c0e958ab5c8f91b
+depends:
+- libgcc >=13
+- __glibc >=2.17,<3.0.a0
+license: BSD-3-Clause
+license_family: BSD
+size: 218500
+timestamp: 1745825989535
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-5.0.0-qt6_hbd3298f_603.conda
+sha256: 898ced2eeadfe5f0a9800c4f457b200499067514aafc0a00c3b288a590cc2cd6
+md5: 0dc9c86c3e3a383960ea3312d5350d7e
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- ffmpeg >=8.1.2,<9.0a0
+- hdf5 >=1.14.6,<1.14.7.0a0
+- imath >=3.2.2,<3.2.3.0a0
+- libavif16 >=1.4.2,<2.0a0
+- libcblas >=3.9.0,<4.0a0
+- libegl >=1.7.0,<2.0a0
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libgl >=1.7.0,<2.0a0
+- libharfbuzz >=14.2.1
+- libiconv >=1.18,<2.0a0
+- libjpeg-turbo >=3.1.4.1,<4.0a0
+- libjxl >=0.12,<0.13.0a0
+- liblapack >=3.9.0,<4.0a0
+- liblapacke >=3.9.0,<4.0a0
+- libopenvino >=2026.2.1,<2026.2.2.0a0
+- libopenvino-auto-batch-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-auto-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-hetero-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-intel-cpu-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-intel-gpu-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-intel-npu-plugin >=2026.2.1,<2026.2.2.0a0
+- libopenvino-ir-frontend >=2026.2.1,<2026.2.2.0a0
+- libopenvino-onnx-frontend >=2026.2.1,<2026.2.2.0a0
+- libopenvino-paddle-frontend >=2026.2.1,<2026.2.2.0a0
+- libopenvino-pytorch-frontend >=2026.2.1,<2026.2.2.0a0
+- libopenvino-tensorflow-frontend >=2026.2.1,<2026.2.2.0a0
+- libopenvino-tensorflow-lite-frontend >=2026.2.1,<2026.2.2.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libstdcxx >=14
+- libtiff >=4.7.2,<4.8.0a0
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- openexr >=3.4.13,<3.5.0a0
+- openjpeg >=2.5.4,<3.0a0
+- qt6-main >=6.11.1,<7.0a0
+license: Apache-2.0
+license_family: Apache
+size: 35517968
+timestamp: 1783114550291
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_5.conda
+sha256: 7bdca717c840e17d7dd050f925dd964da61086c2612b8579a4ff4147105f291f
+md5: d207a2e9bae9da476bc0a603215d5167
+depends:
+- __glibc >=2.17,<3.0.a0
+- libglvnd 1.7.0 ha4b6fd6_5
+license: LicenseRef-libglvnd
+size: 50627
+timestamp: 1787310045795
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h3133023_1.conda
+sha256: 8f9281133322e9eb0bd4a5b11330db1c14f3b40c409639dd3805251151ca52e2
+md5: f749f223bede1bac7724e49d686ac598
+depends:
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libcurl >=8.21.0,<9.0a0
+- libgrpc >=1.82.0,<1.83.0a0
+- libopentelemetry-cpp-headers 1.27.0 ha770c72_1
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libzlib >=1.3.2,<2.0a0
+- nlohmann_json
+- prometheus-cpp >=1.3.0,<1.4.0a0
+constrains:
+- cpp-opentelemetry-sdk =1.27.0
+license: Apache-2.0
+license_family: APACHE
+size: 948783
+timestamp: 1783133058845
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.27.0-ha770c72_1.conda
+sha256: 31349543e3c59c64f17e24494939a22b0e1d611bdb19d98d115775dba423cbf7
+md5: 6cc68cbbe88746be8beaf027d6c64ad3
+license: Apache-2.0
+license_family: APACHE
+size: 394726
+timestamp: 1783133038109
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2026.2.1-h1f0fae8_1.conda
+sha256: 7941fb9ba8c3a5a0a2401dc4120e8fcb561b96d928c43374eb93f545019a2858
+md5: ea41753f926f73966629d81fdf20ec6f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- pugixml >=1.15,<1.16.0a0
+- tbb >=2023.0.0
+license: Apache-2.0
+license_family: APACHE
+size: 6823841
+timestamp: 1782219077259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2026.2.1-h7e124b3_1.conda
+sha256: 3ac14d36fa890840ae8474b8a9f0a094b8542fd8fbc409faf3d465c68f20aff0
+md5: 5698a64698e14e8a2e9e16f8f0de0e2e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libstdcxx >=14
+- tbb >=2023.0.0
+license: Apache-2.0
+license_family: APACHE
+size: 114628
+timestamp: 1782219097820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2026.2.1-h7e124b3_1.conda
+sha256: 499a472fc7b598ad3753b8f2afe60eb5a277d48eca9362e8aca094b2862587a7
+md5: 2ce088ef09292930d4cb3262ce7e144d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libstdcxx >=14
+- tbb >=2023.0.0
+license: Apache-2.0
+license_family: APACHE
+size: 250912
+timestamp: 1782219111223
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2026.2.1-hd41364c_1.conda
+sha256: bec24379598a4405de171ad151945e79743c6bd049aceabf190b753c3f7a11da
+md5: 02e71250f7ca786c4b183d0a39ef63ab
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libstdcxx >=14
+- pugixml >=1.15,<1.16.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 215488
+timestamp: 1782219123433
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2026.2.1-h1f0fae8_1.conda
+sha256: eecc040a7838752a2dff9b4435a4c59bbc67b83e0c880457935b968206cb20b5
+md5: 7288f979a74cfe3fd4b32d8a0dc7baa4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libstdcxx >=14
+- pugixml >=1.15,<1.16.0a0
+- tbb >=2023.0.0
+license: Apache-2.0
+license_family: APACHE
+size: 13637410
+timestamp: 1782219135415
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2026.2.1-h1f0fae8_1.conda
+sha256: a47442ce578b022e19a306f963536a108cc79385f4e09d57a14a849b6a864604
+md5: c0a258b12f0c18c476b8344dbd6db8d5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libstdcxx >=14
+- ocl-icd >=2.3.4,<3.0a0
+- pugixml >=1.15,<1.16.0a0
+- tbb >=2023.0.0
+license: Apache-2.0
+license_family: APACHE
+size: 12367381
+timestamp: 1782219178219
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2026.2.1-h1f0fae8_1.conda
+sha256: 45a91feb68ccce90ad0fa86520572233ca20be56deae0c920f86133d020ad1e8
+md5: c214b149e108e92672e0ee097ebe16f7
+depends:
+- __glibc >=2.17,<3.0.a0
+- level-zero >=1.29.0,<2.0a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libstdcxx >=14
+- pugixml >=1.15,<1.16.0a0
+- tbb >=2023.0.0
+license: Apache-2.0
+license_family: APACHE
+size: 2630818
+timestamp: 1782219217519
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2026.2.1-hd41364c_1.conda
+sha256: ebeba9a3ac9505ee69b556865b7d1b9fbbad01ca1ebe6a4249ff62c3dc677b47
+md5: 2d946aebcf06e9ba438880987050e975
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libstdcxx >=14
+- pugixml >=1.15,<1.16.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 201061
+timestamp: 1782219232657
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2026.2.1-h607c73d_1.conda
+sha256: 7b105c0102356352d6d9518a112ff6343dab6b8f32c837809117cd26cbf006df
+md5: 3bd3599825189418ea14b2c9da3a6d87
+depends:
+- __glibc >=2.17,<3.0.a0
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libstdcxx >=14
+license: Apache-2.0
+license_family: APACHE
+size: 1944558
+timestamp: 1782219246849
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2026.2.1-h607c73d_1.conda
+sha256: af45c03d41ebe0b48c28b68be31ee919cb801ac5077164808a66db515ad6a316
+md5: 91e198085bff9d8fa02d4d947f026ba8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libstdcxx >=14
+license: Apache-2.0
+license_family: APACHE
+size: 690240
+timestamp: 1782219261154
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2026.2.1-hecca717_1.conda
+sha256: e6353874a36143ffb7db7ec2c3767fd5e3434a8eeff41a569bc46e68259f668f
+md5: 152d6694f1d05b53319b8376cdd811e4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libstdcxx >=14
+license: Apache-2.0
+license_family: APACHE
+size: 1226625
+timestamp: 1782219274006
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2026.2.1-h21c0c73_1.conda
+sha256: cffe112815b8eb57528fdfdf8b39f6a0915884291147dab5bc2066d2bf123031
+md5: 89d2455ec2f065786856b0cd2ac1c0c6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libstdcxx >=14
+- snappy >=1.2.2,<1.3.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 1284650
+timestamp: 1782219287644
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2026.2.1-hecca717_1.conda
+sha256: 142e7b24173ca8c32dbdb29c60f33a56ffb21a4ed733c9d6ab160c3a213ff52e
+md5: c1a50f20847df0a8cb462138153ab46f
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libopenvino 2026.2.1 h1f0fae8_1
+- libstdcxx >=14
+license: Apache-2.0
+license_family: APACHE
+size: 501906
+timestamp: 1782219300706
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-hebe6cf0_1.conda
+sha256: 82873b6c8478e19ab7aef0828ad3619b6633ad185a90a52f39dcb2c30c0c075e
+md5: 8a1d977c3d77666406a40c0ab648ff52
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: BSD-3-Clause
+license_family: BSD
+size: 330213
+timestamp: 1787247513612
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-25.0.0-h7376487_4_cpu.conda
+build_number: 4
+sha256: dba948e05d62de3833caa065c1b7de960f921bb0a8a7687b8593df95d2d925a9
+md5: d736a4f89a3b63f9970152923e4c3016
+depends:
+- __glibc >=2.17,<3.0.a0
+- libarrow 25.0.0 hcc2f0d9_4_cpu
+- libgcc >=14
+- libstdcxx >=14
+- libthrift >=0.22.0,<0.22.1.0a0
+- openssl >=3.5.7,<4.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 1412634
+timestamp: 1786315223543
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.19-hb03c661_1.conda
+sha256: addc80c69d362a9e6c40305c493139a8e9ee504b2f45a6687dbdaa9da3c6183c
+md5: 35fa2b34bbced424e6976d30f5fde576
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 30070
+timestamp: 1785971678815
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libplacebo-7.360.1-hc50b9dd_1.conda
+sha256: 7fa90c06b81559cb56ea7806a6696fb4902a1acc20bbaff1bd3a4a75b3ffa0d5
+md5: 4a750e2ae0d52d003bb1e3421581585e
+depends:
+- libstdcxx >=14
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libdovi >=3.4.0,<4.0a0
+- lcms2 >=2.19.1,<3.0a0
+- shaderc >=2026.3,<2026.4.0a0
+- libvulkan-loader >=1.4.341.0,<2.0a0
+license: LGPL-2.1-or-later
+size: 550759
+timestamp: 1784287829706
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+sha256: c19eefb87d70d9b4b0629fa48414a155a47a1be4f04583ae71ed8c5a9a32fdcb
+md5: fcf71c8d979148873f6f8ad4cfc73d86
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libzlib >=1.3.2,<2.0a0
+license: zlib-acknowledgement
+size: 316643
+timestamp: 1786616563127
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-18.6-h9d76c99_0.conda
+sha256: b1eb210c180fda9c445b11cba1286ec250ce2c2a85ccb0551a4ed5423df51e68
+md5: 72e019c04ed02a179da38c56965802d1
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=15
+- openldap >=2.6.13,<2.7.0a0
+- openssl >=3.5.7,<4.0a0
+license: PostgreSQL
+size: 2719680
+timestamp: 1786641133110
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-7.35.1-h622638d_3.conda
+sha256: 37c51fbc936a6bb8bf5f67c8f056edacaaa41e8603738bc8a4dee186292bb114
+md5: fd307b61cceb36fdca38e1718bdb2893
+depends:
+- __glibc >=2.17,<3.0.a0
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libgcc >=15
+- libstdcxx >=15
+- libzlib >=1.3.2,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 3808338
+timestamp: 1787657986197
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpsl-0.23.1-hd9e3e90_1.conda
+sha256: 09e8effdc89bc5d021349318d32b85594f5b8d8e3ab8f90a85b81f8fe695a566
+md5: 77be60417aa572afcb48cbe0f967401d
+depends:
+- libstdcxx >=15
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+license: MIT
+license_family: MIT
+size: 72519
+timestamp: 1786970753847
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.12.14-h0c77377_3_cpython.conda
+build_number: 3
+sha256: 6be16a4906d83eb8e9e04375d524f339f426a847cffd294f1ceb0611988dc17a
+md5: d247b7632f09324c11f24b5270361385
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+license: Python-2.0
+size: 8770625
+timestamp: 1788392466381
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libraqm-0.11.0-h6406941_0.conda
+sha256: ab3ccb9fd5816f76b18ee8974d359cd2605ca87d8ddef55369dc461b9986f95c
+md5: 3ac89a48d224409739dbf6200e524373
+depends:
+- libgcc >=14
+- __glibc >=2.28,<3.0.a0
+- fribidi >=1.0.16,<2.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libharfbuzz >=14.2.1
+license: MIT
+license_family: MIT
+size: 33983
+timestamp: 1784850267262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h60473fc_2.conda
+sha256: 43132eb45a569b1f63199b0e7d5874d94227e9be950b327a323e7dcc1f8cd58c
+md5: ee5c400d37b79db5d32a69ed1a79fc0b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libgcc >=14
+- libstdcxx >=14
+constrains:
+- re2 2025.11.05.*
+license: BSD-3-Clause
+license_family: BSD
+size: 210598
+timestamp: 1781312565737
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.62.3-h4c96295_0.conda
+sha256: 5571bd8239d71961d4e3ce972f865b3ea95a91ce0b53d5749fe2dd24254ddbda
+md5: 492c8d9b1c564c2e948b6cb4ba0f8261
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- fontconfig >=2.18.0,<3.0a0
+- fonts-conda-ecosystem
+- gdk-pixbuf >=2.44.6,<3.0a0
+- harfbuzz >=14.2.0
+- libgcc >=14
+- libglib >=2.88.1,<3.0a0
+- libxml2-16 >=2.14.6
+- pango >=1.56.4,<2.0a0
+constrains:
+- __glibc >=2.17
+license: LGPL-2.1-or-later
+size: 3476570
+timestamp: 1780450632624
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h46dd2a8_20.conda
+sha256: eb4082a5135102f5ba9c302da13164d4ed1181d5f0db9d49e5e11a815a7b526f
+md5: df81fd57eacf341588d728c97920e86d
+depends:
+- __glibc >=2.17,<3.0.a0
+- geos >=3.14.1,<3.14.2.0a0
+- libgcc >=14
+- libstdcxx >=14
+license: GPL-2.0-or-later
+license_family: GPL
+size: 231670
+timestamp: 1761670395043
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+sha256: 57cb5f92110324c04498b96563211a1bca6a74b2918b1e8df578bfed03cc32e4
+md5: 067590f061c9f6ea7e61e3b2112ed6b3
+depends:
+- __glibc >=2.17,<3.0.a0
+- lame >=3.100,<3.101.0a0
+- libflac >=1.5.0,<1.6.0a0
+- libgcc >=14
+- libogg >=1.3.5,<1.4.0a0
+- libopus >=1.5.2,<2.0a0
+- libstdcxx >=14
+- libvorbis >=1.3.7,<1.4.0a0
+- mpg123 >=1.32.9,<1.33.0a0
+license: LGPL-2.1-or-later
+license_family: LGPL
+size: 355619
+timestamp: 1765181778282
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-gpl_hab3fe16_120.conda
+sha256: 1226948565ea9fa4fbaefc8c5ff6bb4c66e3cb96a9db71d236dcc0be0bc319cb
+md5: 5947bdda89ced07ab0d8a5d6503082c3
+depends:
+- __glibc >=2.17,<3.0.a0
+- freexl >=2
+- freexl >=2.0.0,<3.0a0
+- geos >=3.14.1,<3.14.2.0a0
+- libgcc >=14
+- librttopo >=1.1.0,<1.2.0a0
+- libsqlite >=3.51.2,<4.0a0
+- libstdcxx >=14
+- libxml2
+- libxml2-16 >=2.14.6
+- libxml2-devel
+- libzlib >=1.3.1,<2.0a0
+- proj >=9.8.0,<9.9.0a0
+- sqlite
+- zlib
+license: MPL-1.1
+license_family: MOZILLA
+size: 4094822
+timestamp: 1772594360111
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+md5: e72bbec309c2b0f37823ee7d4fabfcd3
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=15
+- libzlib >=1.3.2,<2.0a0
+license: blessing
+size: 974348
+timestamp: 1787051145557
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-h6154650_1.conda
+sha256: 7e463000fa1cba3f3a6597b776f6ab301d425a96e3bc20d0d9d76a3b9f237aa3
+md5: 5c526561e1d2a2e071941174eae84557
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.7,<4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 306045
+timestamp: 1786713107897
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc 16.2.0 ha9f2e26_4
+constrains:
+- libstdcxx-ng ==16.2.0=*_4
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 6613148
+timestamp: 1787618704262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-16.2.0-hdf11a46_4.conda
+sha256: 4cdebd87b76cf53a58a08ebd6d15336daa79c5f0aa34d83a895ac503c0203632
+md5: de0dceacf3e33c5fc88e167885dc8274
+depends:
+- libstdcxx 16.2.0 h934c35e_4
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+size: 28459
+timestamp: 1787618737021
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-h084b8d7_1.conda
+sha256: 2293884d59cf0436c37fc0a4bad71011a8de2a6913610d1c701a7703377c1f75
+md5: ea0da9c20bbb221b530810c3c68bbe62
+depends:
+- __glibc >=2.17,<3.0.a0
+- libcap >=2.78,<2.79.0a0
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 493022
+timestamp: 1780084748140
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h7d032f7_2.conda
+sha256: af6025aa4a4fc3f4e71334000d2739d927e2f678607b109ec630cc17d716918a
+md5: b6e326fbe1e3948da50ec29cee0380db
+depends:
+- __glibc >=2.17,<3.0.a0
+- libevent >=2.1.12,<2.1.13.0a0
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.6,<4.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 423861
+timestamp: 1777018957474
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-hcc2c06a_1.conda
+sha256: 10e125da82ca93e09191e66e5a94d566b2cf8d4024e2a0db3a9114297447e0d9
+md5: 0907d876f460ebc941ae590338b6102f
+depends:
+- __glibc >=2.17,<3.0.a0
+- lerc >=4.2.0,<5.0a0
+- libdeflate >=1.25,<1.26.0a0
+- libgcc >=15
+- libjpeg-turbo >=3.2.0,<4.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=15
+- libwebp-base >=1.6.0,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: HPND
+size: 459753
+timestamp: 1787755584172
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.13.0-cpu_mkl_h40bd1c6_102.conda
+sha256: 5c2eecda8a606b5616b724633b395d5adfb1aa5302356a13e36030b6b11fe237
+md5: ade0fe2ec049a598697733b3acff1de5
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex * *_llvm
+- _openmp_mutex >=4.5
+- fmt >=12.1.0,<12.2.0a0
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libblas * *mkl
+- libcblas >=3.11.0,<4.0a0
+- libgcc >=14
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libstdcxx >=14
+- libuv >=1.52.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- llvm-openmp >=22.1.8
+- mkl >=2026.1.0,<2027.0a0
+- onednn >=3.12,<4.0a0
+- pybind11-abi 11
+- sleef >=3.9.0,<4.0a0
+constrains:
+- pytorch 2.13.0 cpu_mkl_*_102
+- pytorch-cpu 2.13.0
+- pytorch-gpu <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 60881910
+timestamp: 1786374025450
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-h084b8d7_1.conda
+sha256: 287d05680e49eea51b8145fbf34bc213c0618b04f32e450e9da5d715e5134e38
+md5: 89e5671a076d99516a6acd72a35b1640
+depends:
+- __glibc >=2.17,<3.0.a0
+- libcap >=2.78,<2.79.0a0
+- libgcc >=14
+license: LGPL-2.1-or-later
+size: 145969
+timestamp: 1780084753104
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+sha256: 71c8b9d5c72473752a0bb6e91b01dd209a03916cb71f36cc6a564e3a2a132d7a
+md5: e179a69edd30d75c0144d7a380b88f28
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 75995
+timestamp: 1757032240102
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.14-hb700be7_0.conda
+sha256: 3d17b7aa90610afc65356e9e6149aeac0b2df19deda73a51f0a09cf04fd89286
+md5: 56f65185b520e016d29d01657ac02c0d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: MIT
+license_family: MIT
+size: 154203
+timestamp: 1770566529700
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+sha256: 89c84f5b26028a9d0f5c4014330703e7dff73ba0c98f90103e9cef6b43a5323c
+md5: d17e3fb595a9f24fa9e149239a33475d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libudev1 >=257.4
+license: LGPL-2.1-or-later
+size: 89551
+timestamp: 1748856210075
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
+sha256: ecbf4b7520296ed580498dc66a72508b8a79da5126e1d6dc650a7087171288f9
+md5: 1247168fe4a0b8912e3336bccdbf98a5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 85969
+timestamp: 1768735071295
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+md5: 74a0a409d9f4561265d36b789d3f398a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: BSD-3-Clause
+license_family: BSD
+size: 39998
+timestamp: 1788347719520
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+md5: 01c4ed87826af55996768af6dbc936b4
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 420040
+timestamp: 1785914567661
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.24.1-hb83e432_1.conda
+sha256: ce7fbe2855257467196613b9fa2bdedb36d4fc3419c43804e52cfe9eb094a35e
+md5: c3e6df2790fff34ba708722052f02c0e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libdrm >=2.4.129,<2.5.0a0
+- libegl >=1.7.0,<2.0a0
+- libgcc >=15
+- libgl >=1.7.0,<2.0a0
+- libglx >=1.7.0,<2.0a0
+- libxcb >=1.17.0,<2.0a0
+- wayland >=1.26.0,<2.0a0
+- wayland-protocols
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxext >=1.3.7,<2.0a0
+- xorg-libxfixes >=6.0.2,<7.0a0
+license: MIT
+license_family: MIT
+size: 225085
+timestamp: 1787800245924
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+sha256: ca494c99c7e5ecc1b4cd2f72b5584cef3d4ce631d23511184411abcbb90a21a5
+md5: b4ecbefe517ed0157c37f8182768271c
+depends:
+- libogg
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+- libogg >=1.3.5,<1.4.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 285894
+timestamp: 1753879378005
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.16.0-h54a6638_0.conda
+sha256: 38850657dd6835613ef16b34895a54bea98bc7639db6a649c886b331635714fc
+md5: 9f6b0090c3902b2c763a16f7dace7b6e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- intel-media-driver >=26.1.2,<26.2.0a0
+- libva >=2.23.0,<3.0a0
+license: MIT
+license_family: MIT
+size: 287992
+timestamp: 1772980546550
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hd2095e1_1.conda
+sha256: fa57017db022e72a4bf7f0136998340fff87a1f1304b4f6c91d9947ff2fdc9e4
+md5: dc42f5b888d93c7bbc6d0896be967e06
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+license: BSD-3-Clause
+license_family: BSD
+size: 1119517
+timestamp: 1787250109176
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.357.0-h0e34353_2.conda
+sha256: a70c25b66321ee77f9892b205e3247263c400803f543dc8aca53d569a59c5a77
+md5: c5f5f159b66332152197893427071695
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=15
+- libgcc >=15
+- xorg-libxrandr >=1.5.5,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+constrains:
+- libvulkan-headers 1.4.357.0.*
+license: Apache-2.0
+license_family: APACHE
+size: 206957
+timestamp: 1787491938583
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+sha256: 8415001414f488c85b72b9d8cc2071dfb3981a47bc3c8eb56ef91a57d12eae7f
+md5: 9332b53d0ea93c5d39e33be03a0c611a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- libwebp 1.6.0
+license: BSD-3-Clause
+license_family: BSD
+size: 428430
+timestamp: 1785954557217
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_2.conda
+sha256: 7b49e6fd2a584b7f072943e6adf4149677af5121246975278804782d37752837
+md5: 61f0ffba9161cbb3a77722869b21e4bb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- pthread-stubs
+- xorg-libxau >=1.0.12,<2.0a0
+- xorg-libxdmcp >=1.1.5,<2.0a0
+license: MIT
+license_family: MIT
+size: 395120
+timestamp: 1787885788278
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+sha256: f7e9292dd219a6435bbb1223da9586c3e70d66d169c5a92f08db3f2127df04e9
+md5: f7a7ff5a6ab331e037abd34f379a631d
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: LGPL-2.1-or-later
+size: 101957
+timestamp: 1785887123445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.2-h51789e4_1.conda
+sha256: d44878d396713ccf3b355df617f61c40a1442fffcf134392bc6ce0e6c2219369
+md5: f888787e0eab7a8076a67d197e155ffc
+depends:
+- xkeyboard-config
+- libstdcxx >=14
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libxcb >=1.17.0,<2.0a0
+- xorg-libxau >=1.0.12,<2.0a0
+- libxml2
+- libxml2-16 >=2.14.6
+license: MIT AND MIT-open-group AND HPND AND HPND-sell-variant AND ISC
+size: 942571
+timestamp: 1787178780572
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libiconv >=1.18,<2.0a0
+- liblzma >=5.8.3,<6.0a0
+- libxml2-16 2.15.3 hca6bf5a_1
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 46203
+timestamp: 1787237584107
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+md5: 20e4d67ec908f0405124f11612c48305
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libiconv >=1.18,<2.0a0
+- liblzma >=5.8.3,<6.0a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- libxml2 2.15.3
+license: MIT
+license_family: MIT
+size: 559721
+timestamp: 1787237579170
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-devel-2.15.3-h49c6c72_1.conda
+sha256: 443ff3b29df8eab5b075abed87e4edbf59ca5602f627a79bffe5b0855ea40ce9
+md5: f986d9c9de80813d076d235f753889ff
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=14
+- libiconv >=1.18,<2.0a0
+- liblzma >=5.8.3,<6.0a0
+- libxml2 2.15.3 h49c6c72_1
+- libxml2-16 2.15.3 hca6bf5a_1
+- libzlib >=1.3.2,<2.0a0
+license: MIT
+license_family: MIT
+size: 80644
+timestamp: 1787237588477
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.45-h8e12856_0.conda
+sha256: 3257043531b6828cbfe3f1c4d843dd29de3898c4c8780efba792ccdd1464c3b1
+md5: be101a81eab00f1abe854c11a68970de
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libxml2
+- libxml2-16 >=2.15.3
+license: MIT
+license_family: MIT
+size: 250892
+timestamp: 1788362459630
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+md5: 0de0122d9570a8ab637c6b73db268389
+depends:
+- __glibc >=2.17,<3.0.a0
+constrains:
+- zlib 1.3.2 *_3
+license: Zlib
+license_family: Other
+size: 63713
+timestamp: 1785362952714
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.bz2
+sha256: ff94f30b2e86cbad6296cf3e5804d442d9e881f7ba8080d92170981662528c6e
+md5: c66fe2d123249af7651ebde8984c51c2
+depends:
+- libgcc-ng >=9.3.0
+- libstdcxx-ng >=9.3.0
+license: Apache-2.0
+license_family: Apache
+size: 168074
+timestamp: 1607309189989
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-23.1.0-h7148c6a_0.conda
+sha256: b6fa85a30cceca3ad7a811ab34f842b9c2ae9d9d4c520e084b62b2abe50e9a70
+md5: 58b4529023435973ab911c3c51892671
+depends:
+- __glibc >=2.17,<3.0.a0
+constrains:
+- intel-openmp <0.0a0
+- openmp 23.1.0|23.1.0.*
+license: Apache-2.0 WITH LLVM-exception
+license_family: APACHE
+size: 6117432
+timestamp: 1787722419188
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.49.0-py312hb491018_2.conda
+sha256: 6ace01e2178517df371a342ae2ad6666827eeece1bcb9739dee56629873f6ddc
+md5: 77579ddce0dd5f85915bc30259fda6e3
+depends:
+- python
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=15
+- libzlib >=1.3.2,<2.0a0
+- python_abi 3.12.* *_cp312
+- zstd >=1.5.7,<1.6.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 40829032
+timestamp: 1788013772362
+- conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
+sha256: 9afe0b5cfa418e8bdb30d8917c5a6cec10372b037924916f1f85b9f4899a67a6
+md5: 91e27ef3d05cc772ce627e51cff111c4
+depends:
+- python >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+license: BSD-2-Clause
+license_family: BSD
+size: 8250
+timestamp: 1650660473123
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.1.2-py312h6b9c8db_0.conda
+sha256: 6fb1516afe34854a205491f11150dbe685edea5e9b8bbcc9b1e11066d3c4e790
+md5: 2d6dec3fc48303b8bb63ec71973e7f07
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libxml2
+- libxml2-16 >=2.14.6
+- libxslt >=1.1.43,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: BSD-3-Clause and MIT-CMU
+size: 1593892
+timestamp: 1787133195108
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.5-py312h3d67a73_1.conda
+sha256: e8ae9141c7afcc95555fca7ff5f91d7a84f094536715211e750569fd4bb2caa4
+md5: a669145a2c834895bdf3fcba1f1e5b9c
+depends:
+- python
+- lz4-c
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- python_abi 3.12.* *_cp312
+- lz4-c >=1.10.0,<1.11.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 44154
+timestamp: 1765026394687
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-hee9eb32_2.conda
+sha256: b8c0e930183e6b7f83cd35ace102f2b8c2f0faae41dc05255dc72f247dfc556a
+md5: e38a3253d72ab07d471483f24947e2a2
+depends:
+- libgcc >=15
+- libstdcxx >=15
+- __glibc >=2.17,<3.0.a0
+license: BSD-2-Clause
+license_family: BSD
+size: 181812
+timestamp: 1786717122815
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hebe6cf0_1003.conda
+sha256: a0a1400198e5302d8367f2ed53437ee3cc41dbc463cb481921ce765578780b7a
+md5: 10e0aa58ed390ba598b728badf9eb1b7
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: GPL-2.0-or-later
+license_family: GPL
+size: 191573
+timestamp: 1787049167898
+- conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.11.0-pyhd8ed1ab_0.conda
+sha256: 791137f3e107c73315c74bb0c7be34e5f7c36da1828efbc4584544311121484c
+md5: 0323c95182d828bb1bcf708c4077db3b
+depends:
+- networkx >=3.4
+- numpy >=2.0
+- pandas >=2.3
+- python >=3.12
+- scikit-learn >=1.5
+- scipy >=1.14
+license: BSD-3-Clause
+license_family: BSD
+size: 448635
+timestamp: 1786480374013
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.2.0-pyhd8ed1ab_0.conda
+sha256: 0c4c35376fe920714390d46e4b8d31c876d65f18e1655899e0763ec25f2a902f
+md5: 6d03368f2b2b0a5fb6839df53b2eb5e0
+depends:
+- mdurl >=0.1,<1
+- python >=3.10
+license: MIT
+license_family: MIT
+size: 69017
+timestamp: 1778169663339
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+sha256: 5f3aad1f3a685ed0b591faad335957dbdb1b73abfd6fc731a0d42718e0653b33
+md5: 93a4752d42b12943a355b682ee43285b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+constrains:
+- jinja2 >=3.0.0
+license: BSD-3-Clause
+license_family: BSD
+size: 26057
+timestamp: 1772445297924
+- conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.1-py312h4c94fcb_2.conda
+sha256: 8596841a7adf2ff135a7d3a5266727d7a562046f998e8edf9c568a0b20de7ddd
+md5: 97eb87f2704fc5212a05b5fb6202ace0
+depends:
+- __glibc >=2.17,<3.0.a0
+- contourpy >=1.0.1
+- cycler >=0.10
+- fonttools >=4.28.2
+- freetype
+- kiwisolver >=1.3.1
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=14
+- libraqm >=0.11.0,<0.12.0a0
+- libstdcxx >=14
+- numpy >=1.25
+- numpy >=1.25,<3
+- packaging >=20.0
+- pillow >=9
+- pyparsing >=3
+- python >=3.12,<3.13.0a0
+- python-dateutil >=2.7
+- python_abi 3.12.* *_cp312
+- qhull >=2020.2,<2020.3.0a0
+- tk >=8.6.13,<8.7.0a0
+license: PSF-2.0
+license_family: PSF
+size: 8931979
+timestamp: 1785211134185
+- conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-scalebar-0.9.0-pyhd8ed1ab_0.conda
+sha256: 20085f78b3fca5e8696264bd47fdd4c76bf2085ebf819bddda27cd6cf2c31117
+md5: 05cf7fe9bbd45b12eb6c0ea8fd747307
+depends:
+- matplotlib-base
+- python >=3.9
+license: MIT
+license_family: MIT
+size: 21170
+timestamp: 1737197680653
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+md5: 592132998493b3ff25fd7479396e8351
+depends:
+- python >=3.9
+license: MIT
+license_family: MIT
+size: 14465
+timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.2.2-hc2c9f91_1.conda
+sha256: 83837ffc5db1abfc14de88f5c9f07d1a666f149cd95249777f0ed09073ae7c22
+md5: ade84857af069283ff1e3b7aacae1232
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=15
+- libiconv >=1.18,<2.0a0
+- liblzma >=5.8.3,<6.0a0
+- libstdcxx >=15
+- libzlib >=1.3.2,<2.0a0
+- openssl >=3.5.8,<4.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: Zlib
+license_family: Other
+size: 526042
+timestamp: 1788051267376
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2026.1.0-hd2095e1_245.conda
+sha256: a2699b4db5f93ae7211249f5b8df4981c22765c392cc6d34c18d76994fe3b327
+md5: 5c8b5643ac9b96cd1c5b65a17337ce5c
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex * *_llvm
+- _openmp_mutex >=4.5
+- libgcc >=15
+- libstdcxx >=15
+- llvm-openmp >=23.1.0
+- tbb >=2023.0.0
+license: LicenseRef-IntelSimplifiedSoftwareOct2022
+license_family: Proprietary
+size: 142335878
+timestamp: 1787725704439
+- conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-11.1.0-pyhcf101f3_0.conda
+sha256: 6725c1c8db9d025db763e1bba1acdcff2eb2ae20a7766a71512ea84081033288
+md5: 0e694257dbf916540b749c3ffc808efe
+depends:
+- python >=3.10
+- python
+license: MIT
+license_family: MIT
+size: 71270
+timestamp: 1779478190496
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-ha2cb11d_1.conda
+sha256: 3d56733fe0f44159787ad086d5e7bdab8b69e6a5a9b6b873a8beb3519f3d8d07
+md5: f0f6c8691a9ed4099d1f287a444e251a
+depends:
+- __glibc >=2.17,<3.0.a0
+- gmp >=6.3.0,<7.0a0
+- libgcc >=15
+- mpfr >=4.2.2,<5.0a0
+license: LGPL-3.0-or-later
+license_family: LGPL
+size: 101074
+timestamp: 1787668090174
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-ha2cb11d_1.conda
+sha256: 0be79ef2ee536e0c5d3ddb4a52bbae9f26d08560623299f33db2f4c4a17c525a
+md5: 7dcc10f6c0bc3596d5519a710a84dfd4
+depends:
+- __glibc >=2.17,<3.0.a0
+- gmp >=6.3.0,<7.0a0
+- libgcc >=15
+license: LGPL-3.0-only
+license_family: LGPL
+size: 730409
+timestamp: 1787236218159
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-h8142553_0.conda
+sha256: 72393d525761389d0225534d20f4cd917e255704f337f84939b74464d9bc6acb
+md5: 0dae03fd088c1ca13a8f6c9e5508e36c
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: LGPL-2.1-only
+license_family: LGPL
+size: 487458
+timestamp: 1786190190098
+- conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.4.1-pyhd8ed1ab_0.conda
+sha256: 5bbf2f8179ec43d34d67ca8e4989d216c1bdb4b749fe6cb40e86ebf88c1b5300
+md5: 2e81b32b805f406d23ba61938a184081
+depends:
+- python >=3.10
+license: BSD-3-Clause
+license_family: BSD
+size: 464918
+timestamp: 1773662068273
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.2-py312h9be0db6_1.conda
+sha256: 79266ea6c816d490d6b9f19beb14a683520d8f70df7113a5c18293c20c53fdbf
+md5: 371a80205eebd8c13fcb0218c96a2d9c
+depends:
+- python
+- libstdcxx >=15
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- python_abi 3.12.* *_cp312
+license: Apache-2.0
+license_family: APACHE
+size: 114260
+timestamp: 1788170252387
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
+sha256: 0da7e7f4e69bfd6c98eff92523e93a0eceeaec1c6d503d4a4cd0af816c3fe3dc
+md5: 17c77acc59407701b54404cfd3639cac
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: Apache-2.0
+license_family: APACHE
+size: 100056
+timestamp: 1771611023053
+- conda: https://conda.anaconda.org/conda-forge/noarch/multipledispatch-0.6.0-pyhd8ed1ab_1.conda
+sha256: c6216a21154373b340c64f321f22fec51db4ee6156c2e642fa58368103ac5d09
+md5: 121a57fce7fff0857ec70fa03200962f
+depends:
+- python >=3.6
+- six
+license: BSD-3-Clause
+license_family: BSD
+size: 17254
+timestamp: 1721907640382
+- conda: https://conda.anaconda.org/conda-forge/noarch/multiscale-spatial-image-2.0.3-pyhd8ed1ab_0.conda
+sha256: f956c0e17e2c3c6cb72a140c791af794c96644f15cfc02f47962cb2b1264bff7
+md5: 825d507ea2d1177f6892481d4230b5a6
+depends:
+- dask
+- numpy
+- python >=3.10
+- python-dateutil
+- spatial-image >=1.2.2
+- xarray >=2025.1.2
+- xarray-dataclass >=3.0.0
+- zarr
+license: Apache-2.0
+license_family: APACHE
+size: 28215
+timestamp: 1755085433341
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
+md5: 37293a85a0f4f77bbd9cf7aaefc62609
+depends:
+- python >=3.9
+license: Apache-2.0
+license_family: Apache
+size: 15851
+timestamp: 1749895533014
+- conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-hee9eb32_1.conda
+sha256: c9322797c769560e96025d294f0daacbcf7ed95ae68903dd2e398ffb87fa2c73
+md5: 7de84fd76ec2bdb7ac617507de3d3052
+depends:
+- libstdcxx >=15
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 233133
+timestamp: 1788122511702
+- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.25.0-pyhcf101f3_0.conda
+sha256: e48d972fae8e32ca43eefd1a9649afa3a82b4dda5fe12caa441f0bc9e8d1938d
+md5: 0117bf65e45c951a9b0004172cfaeef6
+depends:
+- python >=3.10
+- python
+license: MIT
+license_family: MIT
+size: 293989
+timestamp: 1787261063562
+- conda: https://conda.anaconda.org/conda-forge/noarch/natsort-8.4.0-pyhcf101f3_2.conda
+sha256: aeb1548eb72e4f198e72f19d242fb695b35add2ac7b2c00e0d83687052867680
+md5: e941e85e273121222580723010bd4fa2
+depends:
+- python >=3.9
+- python
+license: MIT
+license_family: MIT
+size: 39262
+timestamp: 1770905275632
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+md5: ee6c0cd80a60961a1f48aa3e0b91f986
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+size: 911196
+timestamp: 1786355078102
+- conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+sha256: f6a82172afc50e54741f6f84527ef10424326611503c64e359e25a19a8e4c1c6
+md5: a2c1eeadae7a309daed9d62c96012a2b
+depends:
+- python >=3.11
+- python
+constrains:
+- numpy >=1.25
+- scipy >=1.11.2
+- matplotlib-base >=3.8
+- pandas >=2.0
+license: BSD-3-Clause
+license_family: BSD
+size: 1587439
+timestamp: 1765215107045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_2.conda
+sha256: 8f8b554c74b032b3e63a8828fb0ecc7ae4f5c5a6bd0afcf75423d5ff79290cb0
+md5: fe93be7dd9209e6ae673962e3031ff51
+constrains:
+- nlohmann_json-abi ==3.12.0
+license: MIT
+license_family: MIT
+size: 136372
+timestamp: 1785920438981
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.67.0-py312h80505a6_1.conda
+sha256: 9d31b33a0a4a547a5b1827270c4741477a13a01b46443848156f137501829a69
+md5: c5a5f2e76e1dbb4372f73aed9779fd5d
+depends:
+- python
+- llvmlite >=0.49.0,<0.50.0a0
+- numpy >=1.22.3,<2.6
+- libstdcxx >=15
+- libgcc >=15
+- _openmp_mutex >=4.5
+- __glibc >=2.17,<3.0.a0
+- python_abi 3.12.* *_cp312
+- numpy >=1.25,<3
+constrains:
+- tbb >=2021.6.0
+- libopenblas !=0.3.6
+- cuda-version >=11.2
+- cudatoolkit >=11.2
+- scipy >=1.0
+- cuda-python >=11.6
+license: BSD-2-Clause
+license_family: BSD
+size: 6107213
+timestamp: 1787145521097
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numcodecs-0.16.5-py312hf79963d_0.conda
+sha256: ae1ec07448a10cdfcaf5df4a818291b0f4a99eb398e02ea5d7fc5d3c76be108f
+md5: 86a969eeb489119374ec1d2e863777e6
+depends:
+- __glibc >=2.17,<3.0.a0
+- deprecated
+- libgcc >=14
+- libstdcxx >=14
+- msgpack-python
+- numpy >=1.23,<3
+- numpy >=1.24
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+- typing_extensions
+license: MIT
+license_family: MIT
+size: 813229
+timestamp: 1764782491676
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.5.2-py312he827f4e_1.conda
+sha256: be778735f693d6c1e9b877d7a28fd7d9e8c0d695c5b93a4dd5b8ec4a4317ca13
+md5: e70abe6ab4c60ecb6a51e67903bcec07
+depends:
+- python
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+- liblapack >=3.9.0,<4.0a0
+- libcblas >=3.9.0,<4.0a0
+- python_abi 3.12.* *_cp312
+- libblas >=3.9.0,<4.0a0
+constrains:
+- numpy-base <0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 9212503
+timestamp: 1788129260074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.4-hb03c661_1.conda
+sha256: 75f3bf733523a338f73d6c276c4a26634877cd970edb558f2769d9fa52b100a9
+md5: c2871ba95727fd1382c05db66048b64c
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- opencl-headers >=2025.6.13
+license: BSD-2-Clause
+license_family: BSD
+size: 109598
+timestamp: 1780362789611
+- conda: https://conda.anaconda.org/conda-forge/noarch/ome-types-0.6.3-pyhcf101f3_1.conda
+sha256: 58d1f8f77711ff71ee4a29d5ba93b358028d8cf4c82b46005fcf53831b77e9ed
+md5: 61b16f74fc439af65d724d9cbd6061f4
+depends:
+- python >=3.9
+- pydantic >=2.4.0
+- pydantic-extra-types >=2.0.0
+- xsdata >=24.4
+- lxml >=4.8.0
+- pint >=0.15
+- python
+license: MIT
+license_family: MIT
+size: 141958
+timestamp: 1764272129097
+- conda: https://conda.anaconda.org/conda-forge/noarch/ome-zarr-0.18.0-pyhd8ed1ab_0.conda
+sha256: cc5e127cf1f53aef614ee5206ad491fa2458c576d894c20a04b5ce3bf8d980a1
+md5: 075cff2bebc333bb9e5ce0c03fe81021
+depends:
+- aiohttp
+- dask-core >=2025.2.0,!=2025.12.*,!=2026.1.*,!=2026.2.*
+- deprecated
+- fsspec >=0.8,!=2021.07.0,!=2023.9.0
+- numpy
+- ome-zarr-models >=1.6
+- python >=3.12
+- rangehttpserver
+- requests
+- scikit-image >=0.19.0
+- toolz
+- zarr >=3.0.0
+license: BSD-2-Clause
+license_family: BSD
+size: 54920
+timestamp: 1781878908994
+- conda: https://conda.anaconda.org/conda-forge/noarch/ome-zarr-models-1.6-pyhc364b38_0.conda
+sha256: 749a7d7934d4131cb8cbe87fd76775e484a3e022ac030755598c1571c95e98bd
+md5: 77f7ea7ed489a3199aa4c4ff707fba74
+depends:
+- python >=3.11,<3.14
+- zarr >=3.1.1
+- pydantic >=2.11.5
+- pydantic-zarr >=0.8.2
+- python
+license: MIT
+license_family: MIT
+size: 36756
+timestamp: 1773781625018
+- conda: https://conda.anaconda.org/conda-forge/linux-64/onednn-3.12-omp_h83de36e_0.conda
+sha256: 0555c7f54e7192b30412cdb462adcf2151153c03fc9f20c0d6846a9381efea56
+md5: 1edfb47e2c1cce4978bbebc467999977
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: APACHE
+size: 13069211
+timestamp: 1779565995400
+- conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-hecca717_0.conda
+sha256: 8de2f0cd8a659b01abf86e7fbb8cea4f28ada62fd288429a2bbc040db1b98dd0
+md5: c930c8052d780caa41216af7de472226
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+license: Apache-2.0
+license_family: APACHE
+size: 55754
+timestamp: 1773844383536
+- conda: https://conda.anaconda.org/conda-forge/linux-64/opencv-5.0.0-qt6_h12f39d8_603.conda
+noarch: python
+sha256: aa698bdb71feee9b449613f7d4654ee893f8ed6b5d5db627fc8b517c0d0c9e6c
+md5: c38fbb55624116ef9e062f5943aa6ed5
+depends:
+- libopencv 5.0.0 qt6_hbd3298f_603
+- py-opencv 5.0.0 qt6_h6945e2d_603
+license: Apache-2.0
+license_family: Apache
+size: 48949
+timestamp: 1783114612550
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openexr-3.4.15-ha9edf89_0.conda
+sha256: 20eb5025e7dabe02bc89bbdb325ab74cf9193314676775288a392df2edec130d
+md5: c9800c3c6d231e777ca98ac9024cb5cc
+depends:
+- libstdcxx >=15
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.2,<2.0a0
+- openjph >=0.31.0,<0.32.0a0
+- imath >=3.2.2,<3.2.3.0a0
+- libdeflate >=1.25,<1.26.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1226202
+timestamp: 1787620378513
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-h8c49934_2.conda
+sha256: 6d54eeb307488f725a8f14af955467249735fa69ffd822763e53784aff05b8a3
+md5: 2f0b27ebfcbc15298dd99205e91288ba
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+license: BSD-2-Clause
+license_family: BSD
+size: 737036
+timestamp: 1787273914103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-heb1ab33_2.conda
+sha256: 131688a88bea8da92fe418c4558c5073435e2848911bc4c836c3a9dd5994b4aa
+md5: a3f3ac7a68d01c198e276dbb99e62032
+depends:
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=15
+- libtiff >=4.7.2,<4.8.0a0
+- libzlib >=1.3.2,<2.0a0
+- libpng >=1.6.58,<1.7.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 391242
+timestamp: 1788425045145
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjph-0.31.0-h8d634f6_0.conda
+sha256: 3c7a4118c678c43952ea10183388f175a4bcee16a1c61d90dab2fbdafddc45d7
+md5: 49ca947333c62d5985a88cbdd8f59468
+depends:
+- libgcc >=14
+- libstdcxx >=14
+- __glibc >=2.17,<3.0.a0
+- libtiff >=4.7.2,<4.8.0a0
+license: BSD-2-Clause
+license_family: BSD
+size: 295193
+timestamp: 1785149856790
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.13-hbde042b_0.conda
+sha256: 21c4f6c7f41dc9bec2ea2f9c80440d9a4d45a6f2ac13243e658f10dcf1044146
+md5: 680608784722880fbfe1745067570b00
+depends:
+- __glibc >=2.17,<3.0.a0
+- cyrus-sasl >=2.1.28,<3.0a0
+- krb5 >=1.22.2,<1.23.0a0
+- libgcc >=14
+- libstdcxx >=14
+- openssl >=3.5.6,<4.0a0
+license: OLDAP-2.8
+license_family: BSD
+size: 786149
+timestamp: 1775741359582
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+md5: 16e3034a330cc625f2c685edec60cf4e
+depends:
+- __glibc >=2.17,<3.0.a0
+- ca-certificates
+- libgcc >=15
+license: Apache-2.0
+license_family: Apache
+size: 3202955
+timestamp: 1787698780103
+- conda: https://conda.anaconda.org/conda-forge/linux-64/optree-0.20.0-py312ha5105d2_1.conda
+sha256: 69ff772fb28cab37570502cdead621fc1454fa90bb97e9aff83617395912033d
+md5: 2cd722ba7312f819d13ec8a4c2cd9185
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+- typing-extensions >=4.10
+license: Apache-2.0
+license_family: Apache
+size: 579015
+timestamp: 1788504556508
+- conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.1-h443056b_0.conda
+sha256: ae96bc0895a2279f2ea296879e0475333e838cc88754b0c1a4903dd92a7e1b21
+md5: 1280a5f8270f30b89cc8373ecfe8899d
+depends:
+- tzdata
+- libgcc >=14
+- libstdcxx >=14
+- __glibc >=2.17,<3.0.a0
+- snappy >=1.2.2,<1.3.0a0
+- libabseil >=20260526.0,<20260527.0a0
+- libabseil * cxx17*
+- libzlib >=1.3.2,<2.0a0
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- lz4-c >=1.10.0,<1.11.0a0
+- zstd >=1.5.7,<1.6.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 1458252
+timestamp: 1784301236872
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+sha256: c432626b16768b8dab228bfb706f7060c2d462a21c516d240f68f2f902b5a044
+md5: 936687ed80f295a1f5dbcf8bd34c252c
+depends:
+- python >=3.9
+- python
+license: Apache-2.0
+license_family: APACHE
+size: 116363
+timestamp: 1785888127370
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.5-py312h8ecdadd_1.conda
+sha256: 393e529c0574c020a9b790275af10ff35e21cbb4e12740888bd3f214f2f07034
+md5: 85eb29ade84d1bd97be5ec55607efb00
+depends:
+- python
+- numpy >=1.26.0
+- python-dateutil >=2.8.2
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- numpy >=1.23,<3
+- python_abi 3.12.* *_cp312
+constrains:
+- adbc-driver-postgresql >=1.2.0
+- adbc-driver-sqlite >=1.2.0
+- beautifulsoup4 >=4.12.3
+- blosc >=1.21.3
+- bottleneck >=1.4.2
+- fastparquet >=2024.11.0
+- fsspec >=2024.10.0
+- gcsfs >=2024.10.0
+- html5lib >=1.1
+- hypothesis >=6.116.0
+- jinja2 >=3.1.5
+- lxml >=5.3.0
+- matplotlib >=3.9.3
+- numba >=0.60.0
+- numexpr >=2.10.2
+- odfpy >=1.4.1
+- openpyxl >=3.1.5
+- psycopg2 >=2.9.10
+- pyarrow >=13.0.0
+- pyiceberg >=0.8.1
+- pymysql >=1.1.1
+- pyqt5 >=5.15.9
+- pyreadstat >=1.2.8
+- pytables >=3.10.1
+- pytest >=8.3.4
+- pytest-xdist >=3.6.1
+- python-calamine >=0.3.0
+- pytz >=2024.2
+- pyxlsb >=1.0.10
+- qtpy >=2.4.2
+- scipy >=1.14.1
+- s3fs >=2024.10.0
+- sqlalchemy >=2.0.36
+- tabulate >=0.9.0
+- xarray >=2024.10.0
+- xlrd >=2.0.1
+- xlsxwriter >=3.2.0
+- zstandard >=0.23.0
+license: BSD-3-Clause
+license_family: BSD
+size: 14936796
+timestamp: 1785276227779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.58.2-h7bb47b9_1.conda
+sha256: 47c3d25a0bdb0ae50627f9ef2a10345fabfabe0e6620cbcff04e589a644542d3
+md5: 0b889b1c6b472d215d6332c6b195589c
+depends:
+- __glibc >=2.17,<3.0.a0
+- cairo >=1.18.4,<2.0a0
+- fontconfig >=2.18.3,<3.0a0
+- fonts-conda-ecosystem
+- fribidi >=1.0.16,<2.0a0
+- libexpat >=2.8.1,<3.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libgcc >=15
+- libglib >=2.88.3,<3.0a0
+- libharfbuzz >=14.4.0
+- libpng >=1.6.58,<1.7.0a0
+- libzlib >=1.3.2,<2.0a0
+license: LGPL-2.1-or-later
+size: 471814
+timestamp: 1788490377724
+- conda: https://conda.anaconda.org/conda-forge/noarch/param-2.4.2-pyhc455866_0.conda
+sha256: 080b43ac75e32ae876830e59a5fe2b6cc3fbd18c4ce1df6cedfb82cd1a30d6be
+md5: b7a075425adcc95fd5429984a4a5790f
+depends:
+- python >=3.10
+license: BSD-3-Clause
+license_family: BSD
+size: 200443
+timestamp: 1788509766061
+- conda: https://conda.anaconda.org/conda-forge/noarch/partd-1.4.2-pyhd8ed1ab_0.conda
+sha256: 472fc587c63ec4f6eba0cc0b06008a6371e0a08a5986de3cf4e8024a47b4fe6c
+md5: 0badf9c54e24cecfb0ad2f99d680c163
+depends:
+- locket
+- python >=3.9
+- toolz
+license: BSD-3-Clause
+license_family: BSD
+size: 20884
+timestamp: 1715026639309
+- conda: https://conda.anaconda.org/conda-forge/noarch/pathlib-abc-0.5.2-pyh9692d8f_0.conda
+sha256: 70fff431251c35a2fe82a04452e8b37afe71a1d9e04c84c75bc10b70a50ada09
+md5: 9c7e6958c1ddc27ceb271eb7422bee56
+depends:
+- python >=3.10
+license: PSF-2.0
+license_family: PSF
+size: 23607
+timestamp: 1760357881073
+- conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.3-pyhcf101f3_0.conda
+sha256: d204290be1e2d895ebd945ffd310ff00ea6a7670fe20a92a04ade7d197cdadf5
+md5: 13e1355debaf21a0b8c2726697ebb01b
+depends:
+- numpy >=1.4.0
+- packaging
+- python >=3.10
+- python
+license: BSD-2-Clause AND PSF-2.0
+size: 193838
+timestamp: 1788106018957
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-h8b3dc9c_1.conda
+sha256: 9ebb10a4eb3be51ae67d85c679f5a7a50cb040ed25c783e6331a225ea09991d4
+md5: 06f6113cf1ff4a54b65f87ead132a5f1
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- libgcc >=15
+- libzlib >=1.3.2,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 1218833
+timestamp: 1787294571916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py312h38079b3_1.conda
+sha256: 759861dd3f02686c51a9d1a315effef0f43697adf008e69f3574dd05f6a5dda7
+md5: abe0e18aba5d053232155243914a168b
+depends:
+- python
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- lcms2 >=2.19.1,<3.0a0
+- libjpeg-turbo >=3.2.0,<4.0a0
+- tk >=8.6.13,<8.7.0a0
+- zlib-ng >=2.3.3,<2.4.0a0
+- libwebp-base >=1.6.0,<2.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- python_abi 3.12.* *_cp312
+- libtiff >=4.7.2,<4.8.0a0
+- openjpeg >=2.5.4,<3.0a0
+- libxcb >=1.17.0,<2.0a0
+license: HPND
+size: 1059991
+timestamp: 1788263909512
+- conda: https://conda.anaconda.org/conda-forge/noarch/pims-0.7-pyhd8ed1ab_1.conda
+sha256: cc9521b3a517c9c0f5097a96ed2285b89ba3ee291320a26100261fea2130f8bf
+md5: 146adfd93cac5e7c6b5def8f39c917cd
+depends:
+- imageio
+- jinja2
+- numpy >=1.19
+- packaging
+- pillow
+- python >=3.9
+- slicerator >=1.1.0
+- tifffile
+license: BSD-3-Clause
+license_family: BSD
+size: 71357
+timestamp: 1734051228623
+- conda: https://conda.anaconda.org/conda-forge/noarch/pint-0.25.3-pyhc364b38_0.conda
+sha256: f58a03dd2908c15dc65fab7e03a0212c69043466f7f85a4e345470492841782f
+md5: 293c4719f6d62778ffecd18e024a8fcd
+depends:
+- python >=3.11
+- platformdirs >=2.1.0
+- flexcache >=0.3
+- flexparser >=0.4
+- typing_extensions >=4.0.0
+- python
+constrains:
+- numpy >=1.23
+license: BSD-3-Clause
+license_family: BSD
+size: 245230
+timestamp: 1773969991837
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+sha256: 829d8288764282de5a9f7b9169acb75cc7dc0b6c3fe2535cfe87dea3436bbc5d
+md5: 0ee5bb30034b081a1386c1e2c98ab0a7
+depends:
+- libstdcxx >=14
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 376704
+timestamp: 1786106621354
+- conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.11.6-pyh5ded981_0.conda
+sha256: 8fe66c78f015fecfe096e4ff78a2626c4d926cde9b6951cf3b8e1ff0aaeb0a6c
+md5: fb0f75910f804de1d8c6e91f73673d11
+depends:
+- python >=3.11
+- python
+license: MIT
+license_family: MIT
+size: 27515
+timestamp: 1788271419073
+- conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.9.0-pyhd8ed1ab_0.conda
+sha256: 081e52c4612830bf1fd4a9c78eebaf335d1385d74ddfd328b1b2f26b983848eb
+md5: dd4b6337bf8886855db6905b336db3c8
+depends:
+- packaging >=20.0
+- platformdirs >=2.5.0
+- python >=3.10
+- requests >=2.19.0
+license: BSD-3-Clause
+license_family: BSD
+size: 56833
+timestamp: 1769816568869
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+sha256: 4ce2e1ee31a6217998f78c31ce7dc0a3e0557d9238b51d49dd20c52d467a126d
+md5: f2c23a77b25efcad57d377b34bd84941
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+size: 593603
+timestamp: 1769710381284
+- conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.8.1-he0df7b0_0.conda
+sha256: dff6f355025b9a510d9093e29fd970fa1091e758b848c9dec814d96ae63a09ba
+md5: b23619e5e9009eaa070ead0342034027
+depends:
+- sqlite
+- libtiff
+- libcurl
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libstdcxx >=14
+- libtiff >=4.7.1,<4.8.0a0
+- libsqlite >=3.53.0,<4.0a0
+- libcurl >=8.19.0,<9.0a0
+constrains:
+- proj4 ==999999999999
+license: MIT
+license_family: MIT
+size: 3652144
+timestamp: 1775840249166
+- conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
+sha256: 013669433eb447548f21c3c6b16b2ed64356f726b5f77c1b39d5ba17a8a4b8bc
+md5: a83f6a2fdc079e643237887a37460668
+depends:
+- __glibc >=2.17,<3.0.a0
+- libcurl >=8.10.1,<9.0a0
+- libgcc >=13
+- libstdcxx >=13
+- libzlib >=1.3.1,<2.0a0
+- zlib
+license: MIT
+license_family: MIT
+size: 199544
+timestamp: 1730769112346
+- conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.5.2-py312h8a5da7c_0.conda
+sha256: c9138bbb53d4bac010526a8deace8cf764aac13fad5280d0a71556bad6c04d29
+md5: d681d6ad9fa2ca3c8cacb7f3b23d54f3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: Apache-2.0
+license_family: APACHE
+size: 51586
+timestamp: 1780037816755
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h1b36aeb_2.conda
+sha256: 74522f28cf6b905f89771b5b3367966280285dca5b5b8cd09f69c3bfe95c637c
+md5: e59300b9232e82a351a9390bfdfe72f9
+depends:
+- python
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- python_abi 3.12.* *_cp312
+license: BSD-3-Clause
+license_family: BSD
+size: 225441
+timestamp: 1788189998857
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h7cc23a3_1004.conda
+sha256: 4a44fd00ea73b79ca2c89b0727b9ccf61c506ead71e67a9abfa4c590042b5a4a
+md5: bb66b610707b811e3c65181a6431e7a8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: MIT
+license_family: MIT
+size: 9630
+timestamp: 1788381877753
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+sha256: 23c98a5000356e173568dc5c5770b53393879f946f3ace716bbdefac2a8b23d2
+md5: b11a4c6bf6f6f44e5e143f759ffa2087
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libstdcxx >=13
+license: MIT
+license_family: MIT
+size: 118488
+timestamp: 1736601364156
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+sha256: 0a0858c59805d627d02bdceee965dd84fde0aceab03a2f984325eec08d822096
+md5: b8ea447fdf62e3597cb8d2fae4eb1a90
+depends:
+- __glibc >=2.17,<3.0.a0
+- dbus >=1.16.2,<2.0a0
+- libgcc >=14
+- libglib >=2.86.1,<3.0a0
+- libiconv >=1.18,<2.0a0
+- libsndfile >=1.2.2,<1.3.0a0
+- libsystemd0 >=257.10
+- libxcb >=1.17.0,<2.0a0
+constrains:
+- pulseaudio 17.0 *_3
+license: LGPL-2.1-or-later
+license_family: LGPL
+size: 750785
+timestamp: 1763148198088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-5.0.0-qt6_h6945e2d_603.conda
+noarch: python
+sha256: 411233d4a998445313216dc95e705bf214bc07682e2629cc85e34d68aa783218
+md5: c5636d5e41dc17ecd54d2d5192e77af6
+depends:
+- _python_abi3_support 1.*
+- cpython >=3.10
+- libopencv 5.0.0 qt6_hbd3298f_603
+- numpy >=1.21,<3
+- python >=3.10
+license: Apache-2.0
+license_family: Apache
+size: 3835698
+timestamp: 1783114606518
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-25.0.0-py312h7900ff3_0.conda
+sha256: 9b6c4aed5da2a3b8f649e1b73596e0867a5506bed9c3aa45dbaedfb674822191
+md5: 6f1918b7565c3cc5ed047a97ea510e55
+depends:
+- libarrow-acero 25.0.0.*
+- libarrow-dataset 25.0.0.*
+- libarrow-substrait 25.0.0.*
+- libparquet 25.0.0.*
+- pyarrow-core 25.0.0 *_0_*
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: Apache-2.0
+license_family: APACHE
+size: 26079
+timestamp: 1784258397971
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-25.0.0-py312h2054cf2_0_cpu.conda
+sha256: 8b54b732de45d85198e8e9ce5d5b5642c847f4379f917c64a4de48643a3305ee
+md5: aff56abfcef5a031603250b7dc23e9d5
+depends:
+- __glibc >=2.17,<3.0.a0
+- libarrow 25.0.0.* *cpu
+- libarrow-compute 25.0.0.* *cpu
+- libgcc >=14
+- libstdcxx >=14
+- libzlib >=1.3.2,<2.0a0
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+constrains:
+- numpy >=1.23,<3
+- apache-arrow-proc * cpu
+license: Apache-2.0
+license_family: APACHE
+size: 5395858
+timestamp: 1784258391353
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.4-pyh293190f_0.conda
+sha256: f213f735f0c2b9bfcc1358c8bdeb0dfcf3614bf2c47aad68227dabea99b0e0d7
+md5: 2e57132f130bffcb5a8b17092b2871bc
+depends:
+- python >=3.8
+- pybind11-global ==3.0.4 *_0
+- python
+constrains:
+- pybind11-abi ==11
+license: BSD-3-Clause
+license_family: BSD
+size: 251088
+timestamp: 1786199539429
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+sha256: 9e7fe12f727acd2787fb5816b2049cef4604b7a00ad3e408c5e709c298ce8bf1
+md5: f0599959a2447c1e544e216bddf393fa
+license: BSD-3-Clause
+license_family: BSD
+size: 14671
+timestamp: 1752769938071
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.4-pyh648e204_0.conda
+sha256: 25e887672e68188a5fa899efdc116acb01d689989493342aac05781ec1f09b81
+md5: e594cb485091100204e0b77cb5709896
+depends:
+- python >=3.8
+- __unix
+- python
+constrains:
+- pybind11-abi ==11
+license: BSD-3-Clause
+license_family: BSD
+size: 244363
+timestamp: 1786199539429
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyconify-0.2.1-pyhd8ed1ab_0.conda
+sha256: 655e8d5bb3b8d6b9829c3d673f62d2c11d73e55e9fcd932c889e0ede8c302cff
+md5: a36f0190135897b1ecfb0b652922cabe
+depends:
+- python >=3.9
+- requests
+license: BSD-3-Clause
+license_family: BSD
+size: 23211
+timestamp: 1738865313444
+- conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
+sha256: e27e0473fc6723311a0bd48b89b616fa1b996a2f7a2b555338cbbcfb9c640568
+md5: 9c5491066224083c41b6d5635ed7107b
+depends:
+- python >=3.10
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 55886
+timestamp: 1779293633166
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyct-0.6.0-pyhd8ed1ab_0.conda
+sha256: 2857170af7e0a0604bbaa305caaedf117ff59a5aa88553530544e1374509be93
+md5: 9d19c7ea78d067fbbaa2317a85f844e7
+depends:
+- param >=1.7.0
+- python >=3.8
+- pyyaml
+- requests
+constrains:
+- pyct-core <0
+license: BSD-3-Clause
+license_family: BSD
+size: 22142
+timestamp: 1759062813077
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.5-pyhcf101f3_0.conda
+sha256: 701ed8122021f62e1c9a46bdf4932ada911c10afa56ba0459f56da940bcbe5a7
+md5: 2d0f9304fc1cb1e3e94e7b37c14cd70a
+depends:
+- typing-inspection >=0.4.2
+- typing_extensions >=4.14.1
+- python >=3.10
+- annotated-types >=0.6.0
+- pydantic-core ==2.46.5
+- python
+license: MIT
+license_family: MIT
+size: 346633
+timestamp: 1787941273167
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.46.5-py312hc767a74_1.conda
+sha256: a805a64e0e7e5ed22e8f49f0038a5d8cab4b96cf094c8822da75d6823f2377e8
+md5: 2854d36e093d53d0cf81ec433ffd9c4c
+depends:
+- python
+- typing-extensions >=4.6.0,!=4.7.0
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- python_abi 3.12.* *_cp312
+constrains:
+- __glibc >=2.17
+license: MIT
+license_family: MIT
+size: 1877711
+timestamp: 1787928982283
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.1-pyhcf101f3_0.conda
+sha256: 385a900cf5d1d39dafab6088537c58a32d572fd237d7c4598def92c4c1120cb8
+md5: 96513760035d70917819a2840155d23a
+depends:
+- python >=3.10
+- pydantic >=2.5.2
+- python
+constrains:
+- phonenumbers >=8,<9
+- pycountry >=23
+- semver >=3.0.2,<4
+- python-ulid >=1,<4
+- pendulum >=3.0.0,<4.0.0
+- pytz >=2024.1
+- tzdata >=2024a
+license: MIT
+license_family: MIT
+size: 72040
+timestamp: 1773664659868
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.15.0-pyhcf101f3_0.conda
+sha256: 674e1ba12010a88441f817a318d3cec7e7a7682813ebd3f427fbd1c6766a16af
+md5: 687adac0b3eb2dd73762e9f912b4549e
+depends:
+- typing-inspection >=0.4.0
+- python >=3.10
+- pydantic >=2.7.0
+- python-dotenv >=0.21.0
+- python
+license: MIT
+license_family: MIT
+size: 60984
+timestamp: 1786146776076
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-zarr-0.10.0-pyhc364b38_0.conda
+sha256: c3a14ccb6d199ba6349741dd93c1ffafbc7ede26967ff2e5d0a8d38d4fdf141a
+md5: d067d8745d2a45cc8aee1b949ab28224
+depends:
+- python >=3.12
+- zarr >=3.0.0,<4.0.0
+- pydantic >=2.0.0,<3.0.0
+- numpy >=2.0.0
+- packaging >=21.0
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 32330
+timestamp: 1777559424250
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.21.0-pyhcf101f3_0.conda
+sha256: f5f015ff1bc3e1b7fc08eee096b1865234189ae0b82bebdb86a5369116e42fa0
+md5: 2882dee445dfa45b0c5afce3ffb7730a
+depends:
+- python >=3.10
+- python
+license: BSD-2-Clause
+license_family: BSD
+size: 959376
+timestamp: 1786995678795
+- conda: https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.6.0-pyhd8ed1ab_0.conda
+sha256: 183a9247055094c9a84d8a12a9ed67eecfe3b36ee23abfaa3b29a6c532c34317
+md5: 419e5270645b535812a6f8bef5de11aa
+depends:
+- llvmlite >=0.30
+- numba >=0.46
+- numpy >=1.13
+- python >=3.10
+- scikit-learn >=0.19
+- scipy >=1.0
+- setuptools
+license: BSD-2-Clause
+license_family: BSD
+size: 64561
+timestamp: 1785514264433
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.13.0-py312hdb6ebaa_0.conda
+sha256: 99e8fdd42f008ef9e955690efd1790a1182ae5d2eb48e8d8da6f6a1e59bd2899
+md5: 0b2a0e17bd514b53e2d12b8ac16225ae
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libgdal-core >=3.13.1,<3.14.0a0
+- libstdcxx >=14
+- numpy
+- packaging
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: MIT
+license_family: MIT
+size: 690230
+timestamp: 1782492770379
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
+sha256: 417fba4783e528ee732afa82999300859b065dc59927344b4859c64aae7182de
+md5: 3687cc0b82a8b4c17e1f0eb7e47163d5
+depends:
+- python >=3.10
+- python
+license: MIT
+license_family: MIT
+size: 110893
+timestamp: 1769003998136
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.2-py312hb99b6cc_5.conda
+sha256: 8416187ef4766eb2de7bad6e751f0aced2f773c3853057c0eb848b345fedc1aa
+md5: 42e2d36478a1fcc0dbc6358ffdb46786
+depends:
+- python
+- proj
+- certifi
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- python_abi 3.12.* *_cp312
+- proj >=9.8.1,<9.9.0a0
+license: MIT
+license_family: MIT
+size: 572689
+timestamp: 1787945032861
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyqtgraph-0.14.0-pyhd8ed1ab_0.conda
+sha256: f1bc737d8c525a6aeaa687fd4e6ab9d07871be089ec1824349c9dd598e0420ea
+md5: 1a9d422262ef2e0928a90dde1da5b33a
+depends:
+- colorama
+- numpy >=1.25
+- python >=3.10
+constrains:
+- pyqt >=5.15
+- pyside2 >=5.15
+license: MIT
+license_family: MIT
+size: 1436545
+timestamp: 1763549841016
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.2-py312hf143aa3_0.conda
+sha256: 4e25d9259683126c377b219a741e081f7b8daa63aa256435d037cdaa3f453589
+md5: bfcdbf7dfa025bf855ffbf44181c143e
+depends:
+- python
+- qt6-main 6.11.2.*
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+- python_abi 3.12.* *_cp312
+- libclang13 >=22.1.8
+- libopengl >=1.7.0,<2.0a0
+- libgl >=1.7.0,<2.0a0
+- libegl >=1.7.0,<2.0a0
+- libxml2
+- libxml2-16 >=2.14.6
+- libvulkan-loader >=1.4.357.0,<2.0a0
+- qt6-main >=6.11.2,<7.0a0
+- libxslt >=1.1.43,<2.0a0
+license: LGPL-3.0-only
+license_family: LGPL
+size: 13943954
+timestamp: 1787219437874
+- conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
+sha256: ba3b032fa52709ce0d9fd388f63d330a026754587a2f461117cac9ab73d8d0d8
+md5: 461219d1a5bd61342293efa2c0c90eac
+depends:
+- __unix
+- python >=3.9
+license: BSD-3-Clause
+license_family: BSD
+size: 21085
+timestamp: 1733217331982
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.14-h5f976f7_3_cpython.conda
+build_number: 3
+sha256: 14c579b1016da04e4c9f1c5c857272d83ec447317d8c4074a07d59de3cef70ef
+md5: 98be3cf76eca2e8871f907a03aed3b84
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- ld_impl_linux-64 >=2.36.1
+- libexpat >=2.8.1,<3.0a0
+- libffi >=3.7.0,<3.8.0a0
+- libgcc >=15
+- liblzma >=5.8.3,<6.0a0
+- libnsl >=2.0.1,<2.1.0a0
+- libpython 3.12.14 h0c77377_3_cpython
+- libsqlite >=3.53.4,<4.0a0
+- libuuid >=2.42.3,<3.0a0
+- libxcrypt >=4.4.38
+- libzlib >=1.3.2,<2.0a0
+- ncurses >=6.6,<7.0a0
+- openssl >=3.5.8,<4.0a0
+- readline >=8.3,<9.0a0
+- tk >=8.6.13,<8.7.0a0
+- tzdata
+constrains:
+- python_abi 3.12.* *_cp312
+license: Python-2.0
+size: 23044161
+timestamp: 1788392496306
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+md5: 5b8d21249ff20967101ffa321cab24e8
+depends:
+- python >=3.9
+- six >=1.5
+- python
+license: Apache-2.0
+license_family: APACHE
+size: 233310
+timestamp: 1751104122689
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.3-pyhcf101f3_0.conda
+sha256: ad7b2dd059c1b693a09f799cbaf4b9d06ec7677c02c9447be98e0b33a49bc04c
+md5: b55edb60d527ce56226a1026abcb3e2c
+depends:
+- python >=3.10
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 28328
+timestamp: 1787003234261
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.14-hd8ed1ab_3.conda
+sha256: 7096d98d7dd0cdb9256c5714d7228a8ce7aca3bd014304ea5c1673c259df72ef
+md5: 7fafcd204183cfa7c1ae4ad9c2d8d414
+depends:
+- cpython 3.12.14.*
+- python_abi * *_cp312
+license: Python-2.0
+size: 47142
+timestamp: 1788391303150
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-igraph-1.0.0-py312h1289d80_0.conda
+sha256: 5c639d4587c59b72a54ce3a87544cb2bc5b60688acb0b9f32e83007f67972b5e
+md5: 29b32941e0811caa3a318685deb29246
+depends:
+- __glibc >=2.17,<3.0.a0
+- igraph >=1.0.0,<1.1.0a0
+- libgcc >=14
+- libstdcxx >=14
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+- texttable >=1.6.2
+license: GPL-2.0-or-later
+license_family: GPL
+size: 657387
+timestamp: 1761816728227
+- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-9_cp312.conda
+build_number: 9
+sha256: ee9c2922e07afc85fc82d5fa82c9ac2c79da3be3283a5e17bf2f2ae38dbd02fb
+md5: 4c32076993e6270825441d059ab5c18b
+constrains:
+- python 3.12.* *_cpython
+license: BSD-3-Clause
+license_family: BSD
+size: 6751
+timestamp: 1788302823694
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.13.0-cpu_mkl_py312_h999dc20_102.conda
+sha256: bfddc2821f141a89a2e8ce05a22db4e1dda638297ff3cfd147fbd79ea0401b5c
+md5: b139a0a62b1e6ec36a37282f4f3f0fbf
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex * *_llvm
+- _openmp_mutex >=4.5
+- filelock
+- fmt >=12.1.0,<12.2.0a0
+- fsspec
+- jinja2
+- libabseil * cxx17*
+- libabseil >=20260526.0,<20260527.0a0
+- libblas * *mkl
+- libcblas >=3.11.0,<4.0a0
+- libgcc >=14
+- libprotobuf >=7.35.1,<7.35.2.0a0
+- libstdcxx >=14
+- libtorch 2.13.0 cpu_mkl_h40bd1c6_102
+- libuv >=1.52.1,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- llvm-openmp >=22.1.8
+- mkl >=2026.1.0,<2027.0a0
+- networkx
+- numpy >=1.25,<3
+- onednn >=3.12,<4.0a0
+- optree >=0.13.0
+- pybind11
+- pybind11-abi 11
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+- setuptools <82
+- sleef >=3.9.0,<4.0a0
+- sympy >=1.13.3
+- typing_extensions >=4.10.0
+constrains:
+- pytorch-cpu 2.13.0
+- pytorch-gpu <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 27182909
+timestamp: 1786375171404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+sha256: cb142bfd92f6e55749365ddc244294fa7b64db6d08c45b018ff1c658907bfcbf
+md5: 15878599a87992e44c059731771591cb
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+- yaml >=0.2.5,<0.3.0a0
+license: MIT
+license_family: MIT
+size: 198293
+timestamp: 1770223620706
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
+sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
+md5: 353823361b1d27eb3960efb076dfcaf6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+license: LicenseRef-Qhull
+size: 552937
+timestamp: 1720813982144
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.11.2-pl5321h9df5c37_0.conda
+sha256: 00d9bc98d04aeeab6f698ca7fe9d666b157ab39b52cad1af0fa346522705668d
+md5: 2ff98660281d1c6bfebda5bffa52cc89
+depends:
+- libxcb
+- xcb-util
+- xcb-util-wm
+- xcb-util-keysyms
+- xcb-util-image
+- xcb-util-renderutil
+- xcb-util-cursor
+- libgl-devel
+- libegl-devel
+- libgcc >=15
+- libstdcxx >=15
+- __glibc >=2.17,<3.0.a0
+- libglib >=2.88.3,<3.0a0
+- libbrotlicommon >=1.2.0,<1.3.0a0
+- libbrotlienc >=1.2.0,<1.3.0a0
+- libbrotlidec >=1.2.0,<1.3.0a0
+- libvulkan-loader >=1.4.357.0,<2.0a0
+- wayland >=1.26.0,<2.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- libcups >=2.3.3,<2.4.0a0
+- alsa-lib >=1.2.16.1,<1.3.0a0
+- zstd >=1.5.7,<1.6.0a0
+- libtiff >=4.7.2,<4.8.0a0
+- libxml2
+- libxml2-16 >=2.14.6
+- dbus >=1.16.2,<2.0a0
+- libegl >=1.7.0,<2.0a0
+- xorg-libsm >=1.2.6,<2.0a0
+- xcb-util-wm >=0.4.2,<0.5.0a0
+- xorg-libice >=1.1.2,<2.0a0
+- xorg-libxxf86vm >=1.1.7,<2.0a0
+- double-conversion >=3.4.0,<3.5.0a0
+- icu >=78.3,<79.0a0
+- libwebp-base >=1.6.0,<2.0a0
+- krb5 >=1.22.2,<1.23.0a0
+- xorg-libxcursor >=1.2.3,<2.0a0
+- pcre2 >=10.47,<10.48.0a0
+- openssl >=3.5.7,<4.0a0
+- xorg-libxcomposite >=0.4.7,<1.0a0
+- libpng >=1.6.58,<1.7.0a0
+- libjpeg-turbo >=3.2.0,<4.0a0
+- libpq >=18.6,<19.0a0
+- libxcb >=1.17.0,<2.0a0
+- xcb-util >=0.4.1,<0.5.0a0
+- xcb-util-keysyms >=0.4.1,<0.5.0a0
+- xcb-util-renderutil >=0.3.10,<0.4.0a0
+- xcb-util-image >=0.4.0,<0.5.0a0
+- libharfbuzz >=14.3.1
+- fontconfig >=2.18.3,<3.0a0
+- fonts-conda-ecosystem
+- xorg-libxdamage >=1.1.6,<2.0a0
+- libzlib >=1.3.2,<2.0a0
+- libgl >=1.7.0,<2.0a0
+- xorg-libxrandr >=1.5.5,<2.0a0
+- libsqlite >=3.53.4,<4.0a0
+- xcb-util-cursor >=0.1.6,<0.2.0a0
+- libxkbcommon >=1.13.2,<2.0a0
+- libfreetype >=2.14.3
+- libfreetype6 >=2.14.3
+- libdrm >=2.4.129,<2.5.0a0
+- xorg-libxext >=1.3.7,<2.0a0
+- xorg-libxtst >=1.2.5,<2.0a0
+constrains:
+- qt ==6.11.2
+license: LGPL-3.0-only
+license_family: LGPL
+size: 60888449
+timestamp: 1787048975419
+- conda: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.3-pyhd8ed1ab_1.conda
+sha256: b17dd9d2ee7a4f60fb13712883cd2664aa1339df4b29eb7ae0f4423b31778b00
+md5: b49c000df5aca26d36b3f078ba85e03a
+depends:
+- packaging
+- python >=3.9
+license: MIT
+license_family: MIT
+size: 63041
+timestamp: 1749167192680
+- conda: https://conda.anaconda.org/conda-forge/noarch/rangehttpserver-1.4.0-pyhd8ed1ab_1.conda
+sha256: 062166b42e483ff343777577986866e7609b2b22ca2e09fd450bbdcaca7c1d5b
+md5: 57b27a254c074a65f0839bdb1886321c
+depends:
+- python >=3.9
+license: Apache-2.0
+license_family: APACHE
+size: 17019
+timestamp: 1736862656631
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.8.1-h1fbca29_0.conda
+sha256: cf550bbc8e5ebedb6dba9ccaead3e07bd1cb86b183644a4c853e06e4b3ad5ac7
+md5: d83958768626b3c8471ce032e28afcd3
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- __glibc >=2.17
+license: BSD-2-Clause
+license_family: BSD
+size: 5595970
+timestamp: 1772540833621
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h94463f1_2.conda
+sha256: 7279908454f0c87b84ebc4aec6924f02f41a105d88420fb35dfaf5ecd976e0f5
+md5: d83f2ee212d217a6d745a00e5be84671
+depends:
+- libre2-11 2025.11.05 h60473fc_2
+license: BSD-3-Clause
+license_family: BSD
+size: 27397
+timestamp: 1781312576962
+- conda: https://conda.anaconda.org/conda-forge/noarch/readfcs-2.1.0-pyhd8ed1ab_0.conda
+sha256: 2463e1a95a25bbcf121316afc11406fa65956a9ba5e842074f70235b90b5900a
+md5: bf0b8b47c68ce74e06017cfc27e232e1
+depends:
+- anndata
+- flowio
+- python >=3.10,<3.13
+license: Apache-2.0
+license_family: APACHE
+size: 16533
+timestamp: 1764828834705
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+md5: 69c01c781e7c8190bbdaf79e3848c5ca
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- ncurses >=6.6,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+size: 348899
+timestamp: 1787033801506
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.34.2-pyhcf101f3_0.conda
+sha256: 1715246b19c9f85ee022933b4845f2fc14ac9184981b7b7d9b728bec8e9588da
+md5: 4a85203c1d80c1059086ae860836ffb9
+depends:
+- python >=3.10
+- certifi >=2023.5.7
+- charset-normalizer >=2,<4
+- idna >=2.5,<4
+- urllib3 >=1.26,<3
+- python
+constrains:
+- chardet >=3.0.2,<8
+license: Apache-2.0
+license_family: APACHE
+size: 68709
+timestamp: 1778851103479
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
+md5: 0242025a3c804966bf71aa04eee82f66
+depends:
+- markdown-it-py >=2.2.0
+- pygments >=2.13.0,<3.0.0
+- python >=3.10
+- typing_extensions >=4.0.0,<5.0.0
+- python
+license: MIT
+license_family: MIT
+size: 208577
+timestamp: 1775991661559
+- conda: https://conda.anaconda.org/conda-forge/noarch/roifile-2026.7.30-pyhd8ed1ab_0.conda
+sha256: e1f80e7694c657d2e709bfb388e3b23177d7fc3d118f07eab1bb4f0d8d1b29d4
+md5: 08f48a8ebacae092ab5f22b6fe3c2280
+depends:
+- numpy
+- python >=3.12
+license: BSD-3-Clause
+license_family: BSD
+size: 25529
+timestamp: 1785423286609
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.16.6-hbcb56a7_0.conda
+noarch: python
+sha256: fc9e190a1cd67a8ff56b18dd7bd54e861cc68d60f85d9479a12fe95095fc5735
+md5: f5fd5d7420ce4f559441fae583f4c07d
+depends:
+- python
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+constrains:
+- __glibc >=2.17
+license: MIT
+size: 8983605
+timestamp: 1788474545889
+- conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.5-h7e3ee7f_1.conda
+sha256: 7369ac21f3561e2203f5b1600ef0671270057380783ca4b9e15f679ba25db575
+md5: fa1c00d999e83ec20173c9775f71a1f1
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- openssl >=3.5.7,<4.0a0
+license: Apache-2.0
+license_family: Apache
+size: 392607
+timestamp: 1783164766248
+- conda: https://conda.anaconda.org/conda-forge/noarch/scanpy-1.12.4-pyhd8ed1ab_1.conda
+sha256: 440cf430810a9ef3546dc3ccedc3bd2c02aa72e7dd0969be4eedcdf53849138b
+md5: 50541d8671e0889f8a15df1c0ee23976
+depends:
+- anndata >=0.10.8
+- certifi
+- fast-array-utils >=1.4
+- h5py >=3.11
+- joblib
+- legacy-api-wrap >=1.5
+- matplotlib-base >=3.10
+- natsort
+- networkx >=2.8.8
+- numba >=0.60
+- numpy >=2
+- packaging >=25
+- pandas >=2.3
+- patsy
+- pynndescent >=0.5.13
+- python >=3.12
+- scikit-learn >=1.6
+- scipy >=1.13
+- scverse-misc >=0.0.6
+- seaborn >=0.13.2
+- session-info2
+- statsmodels >=0.14.5
+- tqdm
+- typing-extensions
+- umap-learn >=0.5.12
+license: BSD-3-Clause
+license_family: BSD
+size: 1999630
+timestamp: 1788441088434
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.26.0-np2py312h4ae17e4_0.conda
+sha256: 581a2228e6963b0707562f519ff68d6c97fad44711af56d3dbeb4a7377939cce
+md5: 36772b1aa2dbd7b75664294d50fecb79
+depends:
+- imageio >=2.33,!=2.35.0
+- lazy-loader >=0.4
+- networkx >=3.0
+- numpy >=1.24
+- packaging >=21.0
+- pillow >=10.1
+- python
+- scipy >=1.11.4
+- tifffile >=2022.8.12
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+- python_abi 3.12.* *_cp312
+- numpy >=1.23,<3
+constrains:
+- astropy-base >=6.0
+- dask-core >=2023.2.0,!=2024.8.0
+- matplotlib-base >=3.7
+- pooch >=1.6.0
+- pyamg >=5.2
+- pywavelets >=1.6
+- scikit-learn >=1.2
+license: BSD-3-Clause
+license_family: BSD
+size: 18546003
+timestamp: 1766684359934
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.9.0-np2py312h3226591_0.conda
+sha256: 8c0cd0326b5a17ddcf189fc4f119bf6871b7853595c088075847c484a3ed567e
+md5: e6e9b5795bb495325c3b4ebd451519aa
+depends:
+- python
+- numpy >=1.24.1
+- scipy >=1.10.0
+- joblib >=1.4.0
+- threadpoolctl >=3.5.0
+- narwhals >=2.0.1
+- libgcc >=14
+- _openmp_mutex >=4.5
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- numpy >=1.23,<3
+- python_abi 3.12.* *_cp312
+license: BSD-3-Clause
+license_family: BSD
+size: 10038167
+timestamp: 1780401052981
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.18.0-py312h54fa4ab_0.conda
+sha256: c304dfb0bbf0d824d3706623f6437237d7bfc83941bb7b18f80e05abb10ec79e
+md5: f8d242c552b0f7f682451ce95879af5e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libblas >=3.9.0,<4.0a0
+- libcblas >=3.9.0,<4.0a0
+- libgcc >=14
+- libgfortran
+- libgfortran5 >=14.3.0
+- liblapack >=3.9.0,<4.0a0
+- libstdcxx >=14
+- numpy <2.7
+- numpy >=1.23,<3
+- numpy >=2.0.0
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: BSD-3-Clause
+license_family: BSD
+size: 17104066
+timestamp: 1781912972195
+- conda: https://conda.anaconda.org/conda-forge/noarch/scverse-misc-0.1.4-pyhc364b38_0.conda
+sha256: be118efda86f2b6e68030fc6d461b905504e4540e5bf181c4cd7e7af1638c38b
+md5: 798756263215e6b30ccee6c40e497afc
+depends:
+- python >=3.12
+- session-info2
+- typing_extensions
+- python
+license: BSD-3-Clause
+license_family: BSD
+size: 28600
+timestamp: 1787916451332
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+sha256: 987ad072939fdd51c92ea8d3544b286bb240aefda329f9b03a51d9b7e777f9de
+md5: cdd138897d94dc07d99afe7113a07bec
+depends:
+- libstdcxx >=14
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libgl >=1.7.0,<2.0a0
+- sdl3 >=3.2.22,<4.0a0
+- libegl >=1.7.0,<2.0a0
+license: Zlib
+size: 589145
+timestamp: 1757842881
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.16-h5330f5c_0.conda
+sha256: 174a62a3994b205213b0667cfe7ea3d26407403b929e9f111256b29694234fb0
+md5: 1d4b9d45cd87da449d9f7c5c3b9ad6a4
+depends:
+- libstdcxx >=15
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- xorg-libxcursor >=1.2.3,<2.0a0
+- libegl >=1.7.0,<2.0a0
+- dbus >=1.16.2,<2.0a0
+- xorg-libxext >=1.3.7,<2.0a0
+- libxkbcommon >=1.13.2,<2.0a0
+- libunwind >=1.8.3,<1.9.0a0
+- libgl >=1.7.0,<2.0a0
+- liburing >=2.14,<2.15.0a0
+- libvulkan-loader >=1.4.357.0,<2.0a0
+- libusb >=1.0.29,<2.0a0
+- xorg-libxtst >=1.2.5,<2.0a0
+- wayland >=1.26.0,<2.0a0
+- xorg-libxi >=1.8.3,<2.0a0
+- libdrm >=2.4.129,<2.5.0a0
+- xorg-libxscrnsaver >=1.2.4,<2.0a0
+- xorg-libxfixes >=6.0.2,<7.0a0
+- xorg-libx11 >=1.8.13,<2.0a0
+- libudev1 >=257.13
+- pulseaudio-client >=17.0,<17.1.0a0
+license: Zlib
+size: 2151582
+timestamp: 1788377993602
+- conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+noarch: python
+sha256: ea29a69b14dd6be5cdeeaa551bf50d78cafeaf0351e271e358f9b820fcab4cb0
+md5: 62afb877ca2c2b4b6f9ecb37320085b6
+depends:
+- seaborn-base 0.13.2 pyhd8ed1ab_3
+- statsmodels >=0.12
+license: BSD-3-Clause
+license_family: BSD
+size: 6876
+timestamp: 1733730113224
+- conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+sha256: f209c9c18187570b85ec06283c72d64b8738f825b1b82178f194f4866877f8aa
+md5: fd96da444e81f9e6fcaac38590f3dd42
+depends:
+- matplotlib-base >=3.4,!=3.6.1
+- numpy >=1.20,!=1.24.0
+- pandas >=1.2
+- python >=3.9
+- scipy >=1.7
+constrains:
+- seaborn =0.13.2=*_3
+license: BSD-3-Clause
+license_family: BSD
+size: 227843
+timestamp: 1733730112409
+- conda: https://conda.anaconda.org/conda-forge/noarch/session-info2-0.4.2-pyhd8ed1ab_0.conda
+sha256: acb94fa16691e0ebf23cb0b5f12c836cca2984a2278d46cab5e8b869c0040b24
+md5: b23c403fbe4282746ac475bb2e098b26
+depends:
+- python >=3.12
+license: MPL-2.0
+license_family: MOZILLA
+size: 28094
+timestamp: 1786093213770
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-81.0.0-pyh332efcf_0.conda
+sha256: 6ecf738d5590bf228f09c4ecd1ea91d811f8e0bd9acdef341bc4d6c36beb13a3
+md5: d629a398d7bf872f9ed7b27ab959de15
+depends:
+- python >=3.10
+license: MIT
+license_family: MIT
+size: 676888
+timestamp: 1770456470072
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shaderc-2026.3-hcebf71c_1.conda
+sha256: 2fa613c823868ef6e05c2e756b1767269f24796564ea9cf4efde61abaae2816e
+md5: 8f3979185375f21da886fb6cc2630005
+depends:
+- __glibc >=2.17,<3.0.a0
+- glslang >=16,<17.0a0
+- libgcc >=15
+- libstdcxx >=15
+- spirv-tools >=2026,<2027.0a0
+license: Apache-2.0
+license_family: Apache
+size: 113803
+timestamp: 1787710995114
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.1.2-py312h383787d_2.conda
+sha256: da100ac0210f52399faf814f701165058fa2e2f65f5c036cdf2bf99a40223373
+md5: 69e400d3deca12ee7afd4b73a5596905
+depends:
+- __glibc >=2.17,<3.0.a0
+- geos >=3.14.1,<3.14.2.0a0
+- libgcc >=14
+- numpy >=1.23,<3
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: BSD-3-Clause
+license_family: BSD
+size: 631649
+timestamp: 1762523699384
+- conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_2.conda
+sha256: 1d6534df8e7924d9087bd388fbac5bd868c5bf8971c36885f9f016da0657d22b
+md5: 83ea3a2ddb7a75c1b09cea582aa4f106
+depends:
+- python >=3.10
+license: MIT
+license_family: MIT
+size: 15018
+timestamp: 1762858315311
+- conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+sha256: 458227f759d5e3fcec5d9b7acce54e10c9e1f4f4b7ec978f3bfd54ce4ee9853d
+md5: 3339e3b65d58accf4ca4fb8748ab16b3
+depends:
+- python >=3.9
+- python
+license: MIT
+license_family: MIT
+size: 18455
+timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+sha256: 57afc2ab5bdb24cf979964018dddbc5dfaee130b415e6863765e45aed2175ee4
+md5: e8a0b4f5e82ecacffaa5e805020473cb
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- libgcc >=14
+- libstdcxx >=14
+license: BSL-1.0
+size: 1951720
+timestamp: 1756274576844
+- conda: https://conda.anaconda.org/conda-forge/noarch/slicerator-1.1.0-pyhd8ed1ab_1.conda
+sha256: 5340c36cb62b7c8a22c267254c037302fea2670a4fb9d29e10ba36565e2a5510
+md5: 102f1100ad3dcbcf57f789600c9c015a
+depends:
+- python >=3.9
+license: BSD-3-Clause
+license_family: BSD
+size: 15755
+timestamp: 1734051114500
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
+md5: 98b6c9dc80eb87b2519b97bcf7e578dd
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 45829
+timestamp: 1762948049098
+- conda: https://conda.anaconda.org/bioconda/noarch/sopa-2.2.11-pyhdfd78af_0.conda
+sha256: 1c21aae3f0bb837e1fdb35eff238b75c81ea62178d5f8cfa28f8d03bb97269dd
+md5: 1de0e7fc536de123e613acb2561b6fb4
+depends:
+- anndata >=0.11.0
+- dask-core >=2024.4.1
+- python >=3.11
+- python-igraph >=1.0.0
+- scanpy >=1.10.4
+- spatialdata >=0.7.2
+- spatialdata-io >=0.3.0
+- spatialdata-plot >=0.2.10
+- typer >=0.9.0
+license: BSD-3-Clause
+size: 137639
+timestamp: 1788398488721
+- conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
+sha256: d1e3e06b5cf26093047e63c8cc77b70d970411c5cbc0cb1fad461a8a8df599f7
+md5: 0401a17ae845fa72c7210e206ec5647d
+depends:
+- python >=3.9
+license: Apache-2.0
+license_family: APACHE
+size: 28657
+timestamp: 1738440459037
+- conda: https://conda.anaconda.org/conda-forge/noarch/spatial-image-1.2.3-pyhd8ed1ab_1.conda
+sha256: e3061e6c35096539fe5db240616bc8881a0df66197c836e28a1e2d28aefb3aaa
+md5: c51cc0960a2a5b2dc16a1ccb4f4a3e75
+depends:
+- numpy
+- python >=3.10
+- xarray >=2024.10.0
+- xarray-dataclass >=3.0.0
+license: MIT
+license_family: MIT
+size: 14240
+timestamp: 1756110133818
+- conda: https://conda.anaconda.org/conda-forge/noarch/spatialdata-0.8.0-pyhd8ed1ab_0.conda
+sha256: 67ae01c96fc90a0b01681bf6358f838eb60d4c12aa7a79697be337c55677d127
+md5: 6e983e99b6448efdd22d2c0bc3e76ec4
+depends:
+- anndata >=0.9.1
+- annsel >=0.1.2
+- click
+- dask-core >=2026.3.0
+- dask-image
+- datashader
+- distributed >=2026.3.0
+- fsspec
+- geopandas >=0.14
+- multiscale-spatial-image 2.0.3
+- networkx
+- numba >=0.55.0
+- numpy
+- ome-zarr >=0.16.0
+- pandas
+- pooch
+- pyarrow
+- python >=3.12
+- pytorch
+- rich
+- scikit-image
+- scipy !=1.17.0
+- setuptools
+- shapely >=2.0.1
+- spatial-image >=1.2.3
+- typing_extensions >=4.8.0
+- universal-pathlib >=0.2.6
+- xarray >=2024.10.0
+- xarray-spatial >=0.3.5
+- zarr >=3.0.0
+license: BSD-3-Clause
+license_family: BSD
+size: 153755
+timestamp: 1783420938275
+- conda: https://conda.anaconda.org/conda-forge/noarch/spatialdata-io-0.7.0-pyhd8ed1ab_0.conda
+sha256: 9a106fbebdcf14da6cb7efa6f8a9dfe6f745c32f5e9aa732dc719772d168f980
+md5: 35076c8fde2deecf2861dba853d3d6c6
+depends:
+- anndata
+- click
+- dask
+- dask-image
+- h5py
+- imagecodecs
+- joblib
+- numpy
+- ome-types
+- pyarrow
+- python >=3.11
+- readfcs
+- scanpy
+- scikit-image
+- spatialdata >=0.7.3
+- tifffile >=2023.8.12
+- xmltodict
+license: BSD-3-Clause
+license_family: BSD
+size: 80982
+timestamp: 1778147525060
+- conda: https://conda.anaconda.org/conda-forge/noarch/spatialdata-plot-0.4.2-pyhd8ed1ab_0.conda
+sha256: b3ed91636716202640bc4c5209d8de3cf74667f59dfd902a542c6404ab5c86c8
+md5: c06deb7b620ab6b574a68650ffa74292
+depends:
+- matplotlib-base
+- matplotlib-scalebar
+- python >=3.12
+- scanpy
+- scikit-learn
+- spatialdata >=0.3.0
+license: BSD-3-Clause
+license_family: BSD
+size: 128296
+timestamp: 1787858192400
+- conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.3-h7148c6a_1.conda
+sha256: 1ff7cdc2e65d3980f977a898d07f4e2b1b6f50dbf7e2fed88b3b4221faf34365
+md5: ac9adda1573683c31a8c58850e911273
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+constrains:
+- spirv-headers >=1.4.357.0,<1.4.357.1.0a0
+license: Apache-2.0
+license_family: APACHE
+size: 2380634
+timestamp: 1787525383516
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.53.4-h9ffa6c4_1.conda
+sha256: b01812eff4e950a73933cb3dc14647a97ee377c7fab4858495b80a749ebfbf8b
+md5: d42b24574925bfa3167efb3571c905ad
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=15
+- libsqlite 3.53.4 h13e7031_1
+- libzlib >=1.3.2,<2.0a0
+- ncurses >=6.6,<7.0a0
+- readline >=8.3,<9.0a0
+license: blessing
+size: 205686
+timestamp: 1787051150973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.15.0-np2py312h32d774f_1.conda
+sha256: 39218a053df0c1cf106b0d2104365fb9c7c37f97d8ccba97270d73b6e65efbac
+md5: 2d01f3fca038726411d065894596c854
+depends:
+- python
+- numpy >=1.23.5,<3
+- scipy >=1.8,!=1.9.2
+- pandas >=1.4,!=2.1.0
+- patsy >=0.5.6
+- packaging >=21.3
+- formulaic >=1.1.0
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- python_abi 3.12.* *_cp312
+- numpy >=1.25,<3
+license: BSD-3-Clause
+license_family: BSD
+size: 13538168
+timestamp: 1788196477208
+- conda: https://conda.anaconda.org/conda-forge/noarch/superqt-0.8.2-pyh9208f05_0.conda
+sha256: 9399c15ebb5fc6c8420798e0d239409728b2f3e46c142c0f72d5f5a164ca44c7
+md5: f98df78ba799abb3f903f6be57a07dfb
+depends:
+- pyconify >=0.1.4
+- pygments >=2.4.0
+- python >=3.10
+- qtpy >=2.4.0
+- typing_extensions >=4.5.0
+license: BSD-3-Clause
+license_family: BSD
+size: 82389
+timestamp: 1782583538546
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.2.0-hd2095e1_1.conda
+sha256: 09c242d480632acca31f2a510c9a9f65bb8cca1e82b73d2d0261ec837fff48be
+md5: 3bd5f5f3f6f6431b9f19b35ad4a8ed21
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+license: BSD-2-Clause
+license_family: BSD
+size: 2750545
+timestamp: 1787256261632
+- conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+sha256: 1c8057e6875eba958aa8b3c1a072dc9a75d013f209c26fd8125a5ebd3abbec0c
+md5: 32d866e43b25275f61566b9391ccb7b5
+depends:
+- __unix
+- cpython
+- gmpy2 >=2.0.8
+- mpmath >=1.1.0,<1.5
+- python >=3.10
+license: BSD-3-Clause
+license_family: BSD
+size: 4661767
+timestamp: 1771952371059
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2023.0.0-hab88423_2.conda
+sha256: 30cb9355c2fefc20ff1a3d6566b9714d5614086a2524c07721fc344eb20515ae
+md5: 7073b15f9364ebc118998601ac6ca6a6
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libhwloc >=2.13.0,<2.13.1.0a0
+- libstdcxx >=14
+license: Apache-2.0
+license_family: APACHE
+size: 182331
+timestamp: 1778673758649
+- conda: https://conda.anaconda.org/conda-forge/noarch/tblib-3.2.2-pyhcf101f3_0.conda
+sha256: 6b549360f687ee4d11bf85a6d6a276a30f9333df1857adb0fe785f0f8e9bcd60
+md5: f88bb644823094f436792f80fba3207e
+depends:
+- python >=3.10
+- python
+license: BSD-2-Clause
+license_family: BSD
+size: 19397
+timestamp: 1762956379123
+- conda: https://conda.anaconda.org/conda-forge/noarch/texttable-1.7.0-pyhd8ed1ab_1.conda
+sha256: 68e13546ad89f43321df0793bd5c53731648da85e77b8aa6ab31f7bacb283680
+md5: c6c4b1c304e52f6a9b67d39384660a80
+depends:
+- python >=3.9
+license: LGPL-3.0-only
+license_family: LGPL
+size: 19937
+timestamp: 1734145707699
+- conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+sha256: 6016672e0e72c4cf23c0cf7b1986283bd86a9c17e8d319212d78d8e9ae42fdfd
+md5: 9d64911b31d57ca443e9f1e36b04385f
+depends:
+- python >=3.9
+license: BSD-3-Clause
+license_family: BSD
+size: 23869
+timestamp: 1741878358548
+- conda: https://conda.anaconda.org/conda-forge/noarch/tifffile-2026.8.23-pyhc364b38_0.conda
+sha256: 33a218d81cb1891c4d736fef7a907025f77e38883ef359ff91f117df2d68b7f2
+md5: 18e7a385a8427c70be15793090598063
+depends:
+- python >=3.12
+- numpy >=2.1
+- imagecodecs >=2026.5.10
+- python
+constrains:
+- matplotlib-base >=3.3
+license: BSD-3-Clause
+license_family: BSD
+size: 231923
+timestamp: 1787572590018
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+build_number: 104
+sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+depends:
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+size: 3566806
+timestamp: 1787272857910
+- conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.1.0-pyhd8ed1ab_1.conda
+sha256: 4e379e1c18befb134247f56021fdf18e112fb35e64dd1691858b0a0f3bea9a45
+md5: c07a6153f8306e45794774cf9b13bd32
+depends:
+- python >=3.10
+license: BSD-3-Clause
+license_family: BSD
+size: 53978
+timestamp: 1760707830681
+- conda: https://conda.anaconda.org/conda-forge/noarch/toposort-1.10-pyhd8ed1ab_1.conda
+sha256: f646e7944f722281b27e9dea97c51047840b9f7860e740dbd1869cf7f5b2bd23
+md5: 56bddff4bb4bdfd4badd35cb8312f1a4
+depends:
+- python >=3.9
+license: Apache-2.0
+license_family: APACHE
+size: 14231
+timestamp: 1734343818024
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.8-py312h4c3975b_0.conda
+sha256: 2ea8f8b10e869b675d2fba157b387eaf4eed1696bfc924bb7b28e67d7aa0a947
+md5: 5423c2b8f82d60320e65b9ff30babbdf
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: Apache-2.0
+license_family: Apache
+size: 869730
+timestamp: 1786226754702
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.70.0-pyh8f84b5b_0.conda
+sha256: a4d9e9da15b13f1ab047e7db412e2ed564bc615832e80213cf129b973c3abf4a
+md5: 00953c3b729e03b0ae21f49fdf3441bb
+depends:
+- python >=3.10
+- __unix
+- python
+constrains:
+- envwrap >=0.2
+- ipywidgets >=6.0
+license: MPL-2.0 and MIT
+size: 98184
+timestamp: 1785172528905
+- conda: https://conda.anaconda.org/conda-forge/noarch/typer-0.27.2-pyhcf101f3_0.conda
+sha256: 5809840f0ae1330d0cfa785f573ff53fd3725578a01997ca36c7f0e2da1ef4d0
+md5: d076f2370a590b3698399256b9b135e3
+depends:
+- annotated-doc >=0.0.2
+- colorama
+- python >=3.10
+- rich >=13.8.0
+- shellingham >=1.3.0
+- python
+license: MIT AND BSD-3-Clause
+size: 188056
+timestamp: 1787921102267
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.16.0-h69aa097_0.conda
+sha256: b141933ece3518f6d7b75dfb59451e2f26b405a44c18e2518a83e9a02e09315c
+md5: c680b5747e8c4c8f23dca0bb7042a8fc
+depends:
+- typing_extensions ==4.16.0 pyhcf101f3_0
+license: PSF-2.0
+license_family: PSF
+size: 94080
+timestamp: 1783002732887
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.4-pyhcf101f3_0.conda
+sha256: 293c66b208468d186a94ff486c2ffbf67859a2bde8c88e965fc9d06c517191b2
+md5: 880e91eac5d926568ef278e20554148e
+depends:
+- python >=3.10
+- typing_extensions >=4.15.0
+- python
+license: MIT
+license_family: MIT
+size: 21070
+timestamp: 1786818918217
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.16.0-pyhcf101f3_0.conda
+sha256: 2d888f90af0686044882c74193ec80a90ec1943145d94a7b1b048958acda1848
+md5: c70ad746c22219b9700931707482992c
+depends:
+- python >=3.10
+- python
+license: PSF-2.0
+license_family: PSF
+size: 52631
+timestamp: 1783002732887
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+size: 118849
+timestamp: 1784250406640
+- conda: https://conda.anaconda.org/conda-forge/linux-64/umap-learn-0.5.12-py312h7900ff3_0.conda
+sha256: 1beab107608c37804197113dbc9f0b96223e5d30c57755506757eed1d5948255
+md5: c111c24423bba40fcbbcf4478366927e
+depends:
+- numba >=0.51.2
+- numpy >=1.17
+- pynndescent >=0.5
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+- scikit-learn >=0.22
+- scipy >=1.3.1
+- setuptools
+- tbb >=2019.0
+- tqdm
+license: BSD-2-Clause
+license_family: BSD
+size: 195585
+timestamp: 1775693699704
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
+sha256: 895bbfe9ee25c98c922799de901387d842d7c01cae45c346879865c6a907f229
+md5: 0b6c506ec1f272b685240e70a29261b8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: Apache-2.0
+license_family: Apache
+size: 410641
+timestamp: 1770909099497
+- conda: https://conda.anaconda.org/conda-forge/noarch/universal-pathlib-0.3.10-hd8ed1ab_0.conda
+sha256: 4a42f4a40563e4521838afb607cf7a4012570a02e768af425d026ac976fc7c4a
+md5: b7f7aee45453d0664717c7a078262c5c
+depends:
+- universal_pathlib >=0.3.10,<0.3.11.0a0
+license: MIT
+license_family: MIT
+size: 7559
+timestamp: 1771855752676
+- conda: https://conda.anaconda.org/conda-forge/noarch/universal_pathlib-0.3.10-pyhd8ed1ab_0.conda
+sha256: c58620fc5979695588835c43b6cee94c35dd6fb2d2ed890ec934c2f09ad3ad2c
+md5: 62c51c758ef3d6a4d5076e84109452a6
+depends:
+- fsspec >=2024.5.0
+- pathlib-abc >=0.5.1,<0.6.0
+- python >=3.10
+license: MIT
+license_family: MIT
+size: 66603
+timestamp: 1771855751804
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
+sha256: 2aad2aeff7c69a2d7eecd7b662eef756b27d6a6b96f3e2c2a7071340ce14543e
+md5: d71d3a66528853c0a1ac2c02d79a0284
+depends:
+- libgcc-ng >=12
+- libstdcxx-ng >=12
+license: BSD-3-Clause
+license_family: BSD
+size: 48270
+timestamp: 1715010035325
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
+sha256: feff959a816f7988a0893201aa9727bbb7ee1e9cec2c4f0428269b489eb93fb4
+md5: cbb88288f74dbe6ada1c6c7d0a97223e
+depends:
+- backports.zstd >=1.0.0
+- brotli-python >=1.2.0
+- h2 >=4,<5
+- pysocks >=1.5.6,<2.0,!=1.5.7
+- python >=3.10
+license: MIT
+license_family: MIT
+size: 103560
+timestamp: 1778188657149
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.26.0-hc1c935e_2.conda
+sha256: df65b987979e6d7f88e756494da5a230d4f2d08d17437d04eecd35559c3a04e4
+md5: 88a47e22b53e50865b1cabe2eb648352
+depends:
+- __glibc >=2.17,<3.0.a0
+- libexpat >=2.8.1,<3.0a0
+- libffi >=3.7.0,<3.8.0a0
+- libgcc >=15
+- libstdcxx >=15
+license: MIT
+license_family: MIT
+size: 340058
+timestamp: 1787793849093
+- conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.49-hd8ed1ab_0.conda
+sha256: 04ce686cd187d379344f9b2be7b4da5f431b265dc0944a6b764fab9da9171948
+md5: 0839a3421140d4a9ba93fb988698fc00
+license: MIT
+license_family: MIT
+size: 147954
+timestamp: 1780946721169
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+sha256: 2bf9a40d86d29fd5c30d0febec99d06398143ddeece9ebb175cc5a6d20279943
+md5: f16d4aec5e8135e8e7bba02ef600149e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+size: 38560
+timestamp: 1779439547766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.4.0-py312h1b36aeb_0.conda
+sha256: 53e09feeab7ebd1271d36f2adedc8af3513329b5ab86e7b26316f1ca29a9df47
+md5: ec38f58c4e14a55ac1be0ace3483aff0
+depends:
+- python
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- python_abi 3.12.* *_cp312
+license: BSD-2-Clause
+license_family: BSD
+size: 141669
+timestamp: 1788174911031
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
+md5: 6c99772d483f566d59e25037fea2c4b1
+depends:
+- libgcc-ng >=12
+license: GPL-2.0-or-later
+license_family: GPL
+size: 897548
+timestamp: 1660323080555
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h73f68a7_4.conda
+sha256: fbf129786d8ed8949bddad9959c5edae25dc968efbe43a6567625f66d4bcf3b2
+md5: 5b049cd7e2149701a5e4e7dc90f00075
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+license: GPL-2.0-or-later
+license_family: GPL
+size: 2237095
+timestamp: 1788446524175
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.7.0-pyhc364b38_0.conda
+sha256: 47244c233aeb55de993fe79eebbbb2adc14b388bb0bf2f9dfbaa8aa6610b6345
+md5: f72531e6cf99c98d47306ec917f5e6b9
+depends:
+- python >=3.11
+- numpy >=1.26
+- packaging >=24.2
+- pandas >=2.2
+- python
+constrains:
+- bottleneck >=1.4
+- cartopy >=0.23
+- cftime >=1.6
+- dask-core >=2024.6
+- distributed >=2024.6
+- flox >=0.9
+- h5netcdf >=1.3
+- h5py >=3.11
+- hdf5 >=1.14
+- iris >=3.9
+- matplotlib-base >=3.8
+- nc-time-axis >=1.4
+- netcdf4 >=1.6.0
+- numba >=0.60
+- numbagg >=0.8
+- pint >=0.24
+- pydap >=3.5.0
+- scipy >=1.13
+- seaborn-base >=0.13
+- sparse >=0.15
+- toolz >=0.12
+- zarr >=2.18
+license: Apache-2.0
+license_family: APACHE
+size: 1027069
+timestamp: 1783633473025
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-dataclass-3.0.0-pyhd8ed1ab_1.conda
+sha256: f301fea70359f6018d213915e9c315d809cf66ffb446629f41c6d54dfd53b246
+md5: 28bdef997ed34b2bd0e2865e87979b9b
+depends:
+- numpy >=2.0.0
+- python >=3.9.*
+- typing_extensions >=4.10.0
+- xarray >=2022.3
+license: MIT
+license_family: MIT
+size: 22087
+timestamp: 1753982528899
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-spatial-0.10.17-pyhd8ed1ab_0.conda
+sha256: 06bd429053c04f454e21990ecbf1aa3bc4a56acf8ff4093e1eb00302ecd31ed8
+md5: 0cf7434c4696e7b36555dbb1f75695dd
+depends:
+- datashader >=0.15.0
+- matplotlib-base
+- numba
+- numpy
+- python >=3.12
+- scipy
+- urllib3
+- xarray
+- zstandard
+license: MIT
+license_family: MIT
+size: 5352265
+timestamp: 1784387793135
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+sha256: ad8cab7e07e2af268449c2ce855cbb51f43f4664936eff679b1f3862e6e4b01d
+md5: fdc27cb255a7a2cc73b7919a968b48f0
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- libxcb >=1.17.0,<2.0a0
+license: MIT
+license_family: MIT
+size: 20772
+timestamp: 1750436796633
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.6-hb03c661_0.conda
+sha256: c2be9cae786fdb2df7c2387d2db31b285cf90ab3bfabda8fa75a596c3d20fc67
+md5: 4d1fc190b99912ed557a8236e958c559
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libxcb >=1.13
+- libxcb >=1.17.0,<2.0a0
+- xcb-util-image >=0.4.0,<0.5.0a0
+- xcb-util-renderutil >=0.3.10,<0.4.0a0
+license: MIT
+license_family: MIT
+size: 20829
+timestamp: 1763366954390
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
+sha256: 94b12ff8b30260d9de4fd7a28cca12e028e572cbc504fd42aa2646ec4a5bded7
+md5: a0901183f08b6c7107aab109733a3c91
+depends:
+- libgcc-ng >=12
+- libxcb >=1.16,<2.0.0a0
+- xcb-util >=0.4.1,<0.5.0a0
+license: MIT
+license_family: MIT
+size: 24551
+timestamp: 1718880534789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
+sha256: 546e3ee01e95a4c884b6401284bb22da449a2f4daf508d038fdfa0712fe4cc69
+md5: ad748ccca349aec3e91743e08b5e2b50
+depends:
+- libgcc-ng >=12
+- libxcb >=1.16,<2.0.0a0
+license: MIT
+license_family: MIT
+size: 14314
+timestamp: 1718846569232
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.10-hb711507_0.conda
+sha256: 2d401dadc43855971ce008344a4b5bd804aca9487d8ebd83328592217daca3df
+md5: 0e0cbe0564d03a99afd5fd7b362feecd
+depends:
+- libgcc-ng >=12
+- libxcb >=1.16,<2.0.0a0
+license: MIT
+license_family: MIT
+size: 16978
+timestamp: 1718848865819
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.2-hb711507_0.conda
+sha256: 31d44f297ad87a1e6510895740325a635dd204556aa7e079194a0034cdd7e66a
+md5: 608e0ef8256b81d04456e8d211eee3e8
+depends:
+- libgcc-ng >=12
+- libxcb >=1.16,<2.0.0a0
+license: MIT
+license_family: MIT
+size: 51689
+timestamp: 1718844051451
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.3.0-h78fed68_2.conda
+sha256: 1acbd62b33b6efc985f70e0b9f0013ca18fcef2df5a18edb1c81a6b63ad20dc0
+md5: f2ff0de6c209e90c53b3a195c2708f5f
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=15
+- libnsl >=2.0.1,<2.1.0a0
+- libstdcxx >=15
+license: Apache-2.0
+license_family: Apache
+size: 1675829
+timestamp: 1788144975107
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.48-h280c20c_0.conda
+sha256: 3b04afd5d1a65d2d27ac2d49a63b01ab8bcd875776779ec63e337370ed38afdc
+md5: b233b41be0bf210989d57160ed39b394
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+- xorg-libx11 >=1.8.13,<2.0a0
+license: MIT
+license_family: MIT
+size: 441670
+timestamp: 1782027360439
+- conda: https://conda.anaconda.org/conda-forge/noarch/xmltodict-1.0.4-pyhcf101f3_0.conda
+sha256: 7588e77a5d3885145e693d8b98493952f6efac8f3fabb1c218cd0cbd1a739fad
+md5: 0f02dbcae61967ced21fea829a8ee927
+depends:
+- python >=3.10
+- python
+license: MIT
+license_family: MIT
+size: 20673
+timestamp: 1771770296472
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+sha256: 49b532d1df875c6749d9078b56a76f3f5db49a5abe0ca620b593ed474ef0ebf1
+md5: 85c9442aec283b4e464fa9ecc484a2f3
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: MIT
+license_family: MIT
+size: 62517
+timestamp: 1786474410404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+sha256: ef907caee0665cf3b0f775602cc50e388e3bade8ce22ecade0873ff26604b2fd
+md5: aa7459ed9ad086ba11dda843d764b33d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- xorg-libice >=1.1.2,<2.0a0
+- libuuid >=2.42.2,<3.0a0
+license: MIT
+license_family: MIT
+size: 30739
+timestamp: 1786545374265
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+sha256: 68053eebfa9f0d91666786c8fb5839d989aa9b869add92cb8815228bb2d7302c
+md5: 8c282bbe4808a3cc80a5c98e9aec1cfc
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- libxcb >=1.17.0,<2.0a0
+license: MIT
+license_family: MIT
+size: 839578
+timestamp: 1787087012372
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+sha256: cbf891f6cc1a859347680af1c8562bc6b033bf182a2a3bb536016932be3206de
+md5: f06ef439c280a5f90b8bf62355008dbc
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 16419
+timestamp: 1786381001122
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcomposite-0.4.7-hb03c661_0.conda
+sha256: 048c103000af9541c919deef03ae7c5e9c570ffb4024b42ecb58dbde402e373a
+md5: f2ba4192d38b6cef2bb2c25029071d90
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- xorg-libx11 >=1.8.12,<2.0a0
+- xorg-libxfixes >=6.0.2,<7.0a0
+license: MIT
+license_family: MIT
+size: 14415
+timestamp: 1770044404696
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
+md5: 2ccd714aa2242315acaf0a67faea780b
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+- xorg-libxfixes >=6.0.1,<7.0a0
+- xorg-libxrender >=0.9.11,<0.10.0a0
+license: MIT
+license_family: MIT
+size: 32533
+timestamp: 1730908305254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdamage-1.1.6-hb9d3cd8_0.conda
+sha256: 43b9772fd6582bf401846642c4635c47a9b0e36ca08116b3ec3df36ab96e0ec0
+md5: b5fcc7172d22516e1f965490e65e33a4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+- xorg-libxfixes >=6.0.1,<7.0a0
+license: MIT
+license_family: MIT
+size: 13217
+timestamp: 1727891438799
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+sha256: c50a16c05ccd7fe7dd6d6cfb539f4e9a491d50f9ed7a5c902fec638f7d0d27be
+md5: 2e66c929f3d879708335b6ea4557c838
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: MIT
+license_family: MIT
+size: 21120
+timestamp: 1786381006369
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+sha256: aa9bbe8b278aacc194e280ff5037f9f9a1f2c5b33ed97de8e7f01cfbe90dda43
+md5: e5b6b28536b81b3f4cb20db4668a4642
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- xorg-libx11 >=1.8.13,<2.0a0
+license: MIT
+license_family: MIT
+size: 53124
+timestamp: 1787100841900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-h7cc23a3_1.conda
+sha256: aec84f554fc897bf4085c7bc8b8f0740e4c224e13bca3cc51c93e7699d56f83a
+md5: 09132e874fe0e1f5e4492b0b6b904b6e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- xorg-libx11 >=1.8.13,<2.0a0
+license: MIT
+license_family: MIT
+size: 21440
+timestamp: 1787248059682
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-h7cc23a3_1.conda
+sha256: a523d71344a2f640efe6fc42b88fc261d9cd389d4f9838a5d42dcdb120c2b0c8
+md5: a1412b2b1184dacda45f8476fef2cc25
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxext >=1.3.7,<2.0a0
+- xorg-libxfixes >=6.0.2,<7.0a0
+license: MIT
+license_family: MIT
+size: 49165
+timestamp: 1787257060460
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-h7cc23a3_1.conda
+sha256: 05a7f25d7f7f5cd32b27a019233ece97167fd8ade255bc13a0e49e53387f4c30
+md5: 798a8c9d171859a022e1cb89e7d0eb10
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxext >=1.3.7,<2.0a0
+- xorg-libxrender >=0.9.12,<0.10.0a0
+license: MIT
+license_family: MIT
+size: 31106
+timestamp: 1787246614086
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+sha256: 6901f91d398811e4ec89d7e20a69abac02a7bfebfaf073338b7ea3d1a99685b7
+md5: e470d224a7a5be1b1d021bded7abb536
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- xorg-libx11 >=1.8.13,<2.0a0
+license: MIT
+license_family: MIT
+size: 34645
+timestamp: 1787100191192
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+sha256: 58e8fc1687534124832d22e102f098b5401173212ac69eb9fd96b16a3e2c8cb2
+md5: 303f7a0e9e0cd7d250bb6b952cecda90
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+- xorg-libx11 >=1.8.10,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+license: MIT
+license_family: MIT
+size: 14412
+timestamp: 1727899730073
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-h7cc23a3_4.conda
+sha256: d66525e7b1c492aa179c6c55610fc8dfb0a9a62ea7d4fb9f904fa6af62127f61
+md5: 752a5ac9322e0fbbc24146c1ce3ae44e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- xorg-libx11 >=1.8.13,<2.0a0
+- xorg-libxext >=1.3.7,<2.0a0
+- xorg-libxi >=1.8.3,<2.0a0
+license: MIT
+license_family: MIT
+size: 35052
+timestamp: 1787360025506
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxxf86vm-1.1.7-hb03c661_0.conda
+sha256: 64db17baaf36fa03ed8fae105e2e671a7383e22df4077486646f7dbf12842c9f
+md5: 665d152b9c6e78da404086088077c844
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- xorg-libx11 >=1.8.12,<2.0a0
+- xorg-libxext >=1.3.6,<2.0a0
+license: MIT
+license_family: MIT
+size: 18701
+timestamp: 1769434732453
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xorgproto-2025.1-hebe6cf0_2.conda
+sha256: 28be920cbb36bb674f66a23f368b67733dbbb89b2321e5ed7266d9b415156795
+md5: 7386d38083163c5b5c4a92a1582daaef
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: MIT
+license_family: MIT
+size: 594980
+timestamp: 1788447117643
+- conda: https://conda.anaconda.org/conda-forge/noarch/xsdata-26.2-pyhd8ed1ab_0.conda
+sha256: 3f56fc1d2e9edbb06d6ab8d6ff4621daaf1080661e4f27b8710f4ee8346d7e51
+md5: 7e56e620692c0b20d37ca04a17cddd74
+depends:
+- click >=8.0.0
+- jinja2 >=3.0.0
+- lxml >=5.0.0
+- python >=3.10
+- requests >=2.28.0
+- ruff >=0.9.8
+- toposort >=1.9
+- typing-extensions >=4.12.0
+license: MIT
+license_family: MIT
+size: 265844
+timestamp: 1771220921101
+- conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
+sha256: 663ea9b00d68c2da309114923924686ab6d3f59ef1b196c5029ba16799e7bb07
+md5: 4487b9c371d0161d54b5c7bbd890c0fc
+depends:
+- python >=3.9
+license: BSD-3-Clause
+license_family: BSD
+size: 51732
+timestamp: 1774900074457
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-hebe6cf0_3.conda
+sha256: d164dfa75ecd538f6fd68765defcc06aa875bc697b9b215362d79a2a73125dd0
+md5: e741576fb8f89821ac7c1c537322a33d
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: MIT
+license_family: MIT
+size: 84936
+timestamp: 1787228426393
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.24.5-py312h8a5da7c_0.conda
+sha256: 8d486c008c32f744ce1791c8c35e5e703cc6d805626ee7288a9b7a1032521a3b
+md5: ef4788bdfaa84f3ae3a9c1390eaf3e73
+depends:
+- __glibc >=2.17,<3.0.a0
+- idna >=2.0
+- libgcc >=14
+- multidict >=4.0
+- propcache >=0.2.1
+- python >=3.12,<3.13.0a0
+- python_abi 3.12.* *_cp312
+license: Apache-2.0
+license_family: Apache
+size: 171280
+timestamp: 1784526501141
+- conda: https://conda.anaconda.org/conda-forge/noarch/zarr-3.3.0-pyhc364b38_0.conda
+sha256: 9563025fbe0aab05a099651d087747dda6eea21605e13fbc920c555dc14936b2
+md5: 9ea26dd8ab46e83b7b7faaa891037471
+depends:
+- python >=3.12
+- packaging >=22.0
+- numpy >=2
+- numcodecs >=0.14
+- typing_extensions >=4.14
+- donfig >=0.8
+- google-crc32c >=1.5
+- python
+constrains:
+- fsspec >=2023.10.0
+- obstore >=0.5.1
+license: MIT
+license_family: MIT
+size: 471664
+timestamp: 1785511642744
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zfp-1.0.1-h909a3a2_5.conda
+sha256: 5fabe6cccbafc1193038862b0b0d784df3dae84bc48f12cac268479935f9c8b7
+md5: 6a0eb48e58684cca4d7acc8b7a0fd3c7
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+- libgcc >=14
+- libstdcxx >=14
+license: BSD-3-Clause
+license_family: BSD
+size: 277694
+timestamp: 1766549572069
+- conda: https://conda.anaconda.org/conda-forge/noarch/zict-3.0.0-pyhd8ed1ab_1.conda
+sha256: 5488542dceeb9f2874e726646548ecc5608060934d6f9ceaa7c6a48c61f9cc8d
+md5: e52c2ef711ccf31bb7f70ca87d144b9e
+depends:
+- python >=3.9
+license: BSD-3-Clause
+license_family: BSD
+size: 36341
+timestamp: 1733261642963
+- conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+sha256: 210bd31c22bb88f5e2a167df24c95bb5f152b2ada7502f9b8c49d1f5366db423
+md5: ba3dcdc8584155c97c648ae9c044b7a3
+depends:
+- python >=3.10
+- python
+license: MIT
+license_family: MIT
+size: 24190
+timestamp: 1779159948016
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_3.conda
+sha256: 16080a1c7724f7d25727cdc23c7658e0cec2db52448c1dc0c33467ee2c6e1c62
+md5: 6acb86426229f96f93e5468d1df3a5e8
+depends:
+- __glibc >=2.17,<3.0.a0
+- libzlib 1.3.2 h25fd6f3_3
+license: Zlib
+license_family: Other
+size: 96132
+timestamp: 1785362957588
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hce19668_1.conda
+sha256: 8b786bb4380fa69a718b08a400040b865bc9207eda337e0a1955717c3c3a9403
+md5: 1726acec19beeed1c764385cd8622405
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+license: Zlib
+license_family: Other
+size: 123959
+timestamp: 1786736890973
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.25.0-py312h1b36aeb_3.conda
+sha256: 7c2b7d721ae03896f4ac7d0d806567ba92786de94efc79e14512f355552bcdca
+md5: b71258304496a49e77c66650459089d1
+depends:
+- python
+- cffi >=1.11
+- zstd >=1.5.7,<1.5.8.0a0
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- zstd >=1.5.7,<1.6.0a0
+- python_abi 3.12.* *_cp312
+license: BSD-3-Clause
+license_family: BSD
+size: 466734
+timestamp: 1787896527572
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+md5: aa459086047c0e5e27023ab19f8cb86a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.2,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+size: 601301
+timestamp: 1786599621503

--- a/modules/local/download_cellpose_model/environment.yml
+++ b/modules/local/download_cellpose_model/environment.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.12
+  - sopa=2.2.11
+  - cellpose=3.1.1.3

--- a/modules/local/download_cellpose_model/main.nf
+++ b/modules/local/download_cellpose_model/main.nf
@@ -16,6 +16,6 @@ process DOWNLOAD_CELLPOSE_MODEL {
     """
     mkdir -p ./cellpose_models
 
-    #sopa download cellpose --model-dir ./cellpose_models ${cli_arguments}
+    sopa download cellpose --model-dir ./cellpose_models ${cli_arguments}
     """
 }

--- a/modules/local/download_cellpose_model/main.nf
+++ b/modules/local/download_cellpose_model/main.nf
@@ -1,6 +1,5 @@
-process PATCH_SEGMENTATION_CELLPOSE {
+process DOWNLOAD_CELLPOSE_MODEL {
     label "process_single"
-    tag "${meta.sample}"
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
@@ -8,17 +7,15 @@ process PATCH_SEGMENTATION_CELLPOSE {
 :         'community.wave.seqera.io/library/python_sopa_cellpose:d098579826bbcf24' }"
 
     input:
-    tuple val(meta), path(sdata_path), val(cli_arguments), val(index), val(n_patches), path(model_dir)
+    val cli_arguments
 
     output:
-    tuple val(meta), path(sdata_path), path("${index}.parquet"), val(n_patches)
+    path "cellpose_models"
 
     script:
     """
-    export CELLPOSE_LOCAL_MODELS_PATH=${model_dir}
+    mkdir -p ./cellpose_models
 
-    sopa segmentation cellpose ${sdata_path} --patch-index ${index} ${cli_arguments}
-
-    mv ${sdata_path}/.sopa_cache/cellpose_boundaries/${index}.parquet ${index}.parquet
+    #sopa download cellpose --model-dir ./cellpose_models ${cli_arguments}
     """
 }

--- a/modules/local/download_stardist_model/.conda-lock/linux_amd64-bd-df074ee8a42c1e8f_1.txt
+++ b/modules/local/download_stardist_model/.conda-lock/linux_amd64-bd-df074ee8a42c1e8f_1.txt
@@ -1,0 +1,3213 @@
+
+version: 6
+environments:
+default:
+channels:
+- url: https://conda.anaconda.org/conda-forge/
+- url: https://conda.anaconda.org/bioconda/
+indexes:
+- https://pypi.org/simple
+options:
+pypi-prerelease-mode: if-necessary-or-explicit
+packages:
+linux-64:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.12.14-h0c77377_3_cpython.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_2.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.14-h5f976f7_3_cpython.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.48.0-pyhd8ed1ab_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+- pypi: https://files.pythonhosted.org/packages/58/0a/a10b45aab35b175aded078a462dc8d0c698f5b13946e7cb0869097b78bb6/absl_py-2.5.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/30/c5/6290519dec32f3cdf6827e3bbcbf7a9f4fb29a55a9204199901fed69957b/aiobotocore-3.9.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/94/ad/33a5291066c4d51be58a8c537545402605feaa9fca49ff51ada6912d0234/anndata-0.13.3.post0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/69/21/3587d7b32dfade1532d9cbb67291cb26f4353c296cadcda6767bd62458d3/annsel-0.1.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/86/16/1a8fd2b19544b84575cf84ef7aa3ad4c173b756d5f087c91f85d1b295777/array_api_compat-1.15.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/5c/cd/86fe9e659e9699f62f8dd5ecd8c6725474334b23cab8aa71d82b5f56f1a4/botocore-1.43.56-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/b8/2a/d5a3434d86fb13522ee39fe1c4a68c11d5c5e2b93d762000557e139f7be9/csbdeep-0.8.2-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/f8/3a/4fc99e788bcfa1b3b3f21abf57da45898d807d007e7f6fd1c7300904eb70/dask-2026.8.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/3f/5b/15d6d6ff8697b188787609be059fe4f07f99fc00f43f68e9e1540fa8733e/dask_image-2026.5.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/cb/41/247627c8b9fef5c605d00546b85771a8fe42975b9616a557cead5468789b/datashader-0.19.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/28/d4/017e2d39d797eaa38a52b4459c8bea875d5e0ada335a62aafe98193041a6/distributed-2026.8.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/be/54/f5add3c73052d18b1fda3eb5dd7a0ced1fccb3b425321c899a084063e406/fast_array_utils-1.5-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/67/61/5af8df9c7c2c96bd1a2cb758b278d467300e5f4714769ba70e4351da1a4f/flowio-1.4.0.tar.gz
+- pypi: https://files.pythonhosted.org/packages/dc/8f/e5f2906ea833d362916c64a2f6b1922a07b19442744fd3cd89563f429bff/fonttools-4.64.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/fc/75/0576b03f7889ad25b5385b4f6c69e0543713425a6f193b056c9b0a2e65ce/formulaic-1.2.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/1d/33/f1c6a276de27b7d7339a34749cc33fa87f077f921969c47185d34a887ae2/gast-0.7.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/59/a8/bd530cc264e62ddbc1d1bb7225823992e6f2432c664693e9281bb6b9c359/geopandas-1.1.4-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/bc/19/9fc702e31a631262d7a752fa699f6022821e707fefc8bff49b1550a57729/grpcio-1.83.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/86/f9/f00de11c82c88bfc1ef22633557bfba9e271e0cb3189ad704183fc4a2644/h5py-3.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/7d/da/dd2867c25adbb41563720f14b5fc895c98bf88be682a3faff4f7b3118d2a/igraph-1.0.0-cp39-abi3-manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/67/1b/0771f9b93a8f43b1e98a20d33fab02a6eceb8bb75c32764b5d47ee4db36f/imagecodecs-2026.8.16-cp312-abi3-manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/3e/2d/ca050652104bab2cf55e569db2a178b1b61cb041fef28307f2db383f6d9f/imageio-2.37.4-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/a1/d3/20a61a248feb1249cd81f83ce731f0bdf5170ed96a08a298f7081cda9e90/interface_meta-2.0.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/18/53/84099323c2ec4be98d935f63c033ac4151ee83836ca1050ede3b3aadf155/joblib-1.6.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/8d/b3/c9b848bbdba18e765a8051917c0cc82585b64278ce87895f2e521a27438f/keras-3.15.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/fc/f4/dadfec469313c7f428efa7e84b4aba9732f813c13ea7131a24b7b008ef57/kiwisolver-1.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/41/5b/058db09c45ba58a7321bdf2294cae651b37d6fec68117265af90cde043b0/legacy_api_wrap-1.5-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/1d/fc/716c1e62e512ef1c160e7984a73a5fc7df45166f2ff3f254e71c58076f7c/libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/be/3c/e97f69c62a2d972066d9a2612ce1f3de313035ac897a5b9f787cad8b55f7/llvmlite-0.49.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/c9/cf/b4ad2cc81b6672ea29ea04e64e350a9f9b493b0908ccd884c67eeff8f7b2/matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/a8/c0/2dfab7b319dabe23f5a7b515a797c74b501d15c72e7a03837cf0cf779b9e/matplotlib_scalebar-0.9.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/c7/f9/7d76c1eae866f5d4636401b31b6d6dd90e4b4ced1fa7cfdfcca9c60e4bd3/ml_dtypes-0.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/41/f0/29f591bea185616cf417645ac03bd3ad9b317483ad8572160e325f7fe777/msgpack-1.2.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/01/a7/fec56dbac873a18930b2127d400794a91dd53898bff811aa4802ddbbfac9/multiscale_spatial_image-2.0.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b2/bc/465daf1de06409cdd4532082806770ee0d8d7df434da79c76564d0f69741/namex-0.1.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/bb/38/926757caaac18a66f057d7544a63620bf360a07d281c9f7ecadd2aa83963/numba-0.67.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/fc/6a/1000cad1700ab0af4d1b1d0a9c23c34badddb4f547c008bde2a6c61968f1/ome_types-0.6.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e0/a5/03e8ae6a8c4dfcc28561354f5ea20073c7b0a640b301b54169a3bf709e87/ome_zarr-0.19.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/2d/70/9ab676f57fe2cb5457db80dd0cc4648b02cbe777d47f159e357391a1e00a/ome_zarr_models-1.8.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/fe/98/6a63875d66bef096d0c040f0cba9d0b14436df88b130d7f779c3dfa59759/optree-0.20.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/35/94/ff5ad5b758c61c1b33755e02c3a653d1d41c36891329e76a8e6b6e69e8b1/param-2.4.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/20/70/cd3cf5cff538323076a879edef02cce6f13f7d75e03d12f211b0a0dbd178/patsy-1.0.3-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/b8/02/5bf3639f5b77e9b183011c08541c5039ba3d04f5316c70312b48a8e003a9/pims-0.7.tar.gz
+- pypi: https://files.pythonhosted.org/packages/27/6e/80993e10a0482f630cef528635789233224f36b1ffd11592aa15d13ff9ce/platformdirs-4.11.7-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/22/df/c799fe7a05ef16ba853a59db01f3a2c5f7d0676469589ccc4874f76a2a88/protobuf-7.36.1-cp310-abi3-manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/60/c9/711ca85d79f1ec98f29a5eae2b051e25b4ecec5de3e3c0e2d5c5dcb15664/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/8c/b2/23f4032cd1c9744aa8e9ecda43cd4d755fcb209f7f40fae035248f31a679/pyct-0.6.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/c7/05/04af0ca9c5747c95591a549509ebbb0a986155015de59f1e4c984e3af9ab/pydantic_zarr-0.10.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/20/c2/247c150f5ca12f8593c20e39115db551b18de5c6cb383006de21b57399e4/pyogrio-0.13.0-cp311-abi3-manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b8/be/212882c450bba74fc8d7d35cbd57e4af84792f0a56194819d98106b075af/pyproj-3.7.2-cp312-cp312-manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/2f/43/d7e2b9ad768c07b5473bea3ac7db9ca4d995c09399cbea3d4df1c0bd4955/rangehttpserver-1.4.0-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/08/40/5946741473075cfed3f4b42a14839cd1672761191dbecff3aa4648b28f63/readfcs-2.1.0-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/98/cc/bcde19a37952ecc58e7d9d67ecaa048e1e21b17d014ce0863a6a6101e606/s3fs-2026.7.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/6f/5c/b8cd4faf65463e7ba3a78d8dd4f60dab9e1b330eb395bd8f654c3b194b63/scanpy-1.12.4-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/df/64/ff35eb9e54894cf471ff4716abd3c81eb0a0626869217ce3e6ba4ccf17d7/scipy-1.18.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/26/13/64f304e0ee7be3ed7da25dd4167a34090aa91b7705330c60cce7ed8bf28e/scverse_misc-0.1.4-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/9b/41/b5af3c12d874fcbdb45abd67500aff8030de0d350a5d6163da45378609c4/session_info2-0.4.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b9/37/e781683abac55dde9771e086b790e554811a71ed0b2b8a1e789b7430dd44/shapely-2.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e8/ae/fa6cd331b364ad2bbc31652d025f5747d89cbb75576733dfdf8efe3e4d62/slicerator-1.1.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/31/fb/4d209f10d89033e0c2c2e8241e5775fa63e3a18e21c7061ac14067612f1a/sopa-2.2.11-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d0/5a/8ef888a4f56fa2ea5c10a7d6ff02286f503a93ea298bcaa9f51a41a20df8/spatial_image-1.2.3-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/cf/08/f5cac3e58d1bb092bfb6015104e6cce925bbe10a2cae44428c790d4e5d06/spatialdata-0.8.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/c9/81/6a081a0db19b9bde838cbed6d46f3e3e540da6673d6c50469287a3719775/spatialdata_io-0.7.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/48/4f/e8662e55ce2dd27c665b2d13a66f5c9808fc74c560d21ab06876b7ceb224/spatialdata_plot-0.4.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d7/0f/74de01918a2578a1785058fff840f0ff8ee0b9402f811c7721a722242bf9/stardist-0.9.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/41/c7/aeadca282baf51d7b9c135674bac79ded91f4db79c69c188575d22234342/statsmodels-0.15.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/ce/d7/6e71b4ded8ce99cd21add95611ca14af6e9ad4f2baeabdeb79a4a6b3cb1f/tensorflow-2.21.0-cp312-cp312-manylinux_2_27_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/24/99/4772b8e00a136f3e01236de33b0efda31ee7077203ba5967fcc76da94d65/texttable-1.7.0-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/82/38/05347ae8b1b268c068b3ca38822558038f38c6494604837d7ca3cbcceb9c/tifffile-2026.8.23-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/6e/de/f2e733f386b85962d1b1dc82cd63d169b5b4580062b35397eac9244a41fe/tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e7/dc/f9a644bf4b67a27ea2dfee8b816eb07e0e2f93da8fb4265e49f2b2af2f1e/transformnd-0.7.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/1b/98/f63318ccbe75c810011fe9233884c5d348d94d90005de1b79e5f93bef9c0/umap_learn-0.5.12-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/f8/fd/b20e3cb3cab35131b515edf18e8cd777dff680fc76fc00919481f4e536af/wrapt-2.4.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/57/5b/28365212062939d213802e5e5fe855cdb231e1c2a93254ba1690066504e3/xarray-2026.7.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/bc/ea/bc1de04d06b7c59fc3ff647a11fa248bf80af5a6227647a31c6250c32ce6/xarray_dataclass-3.0.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/c1/98/80f1eb371b5b053c0edec957ad10fbf1038a4206b9e25fbd4c5ebe11d5cc/xarray_spatial-0.10.17-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d3/92/f0edcbc2f895ecea14a68e492b24c157625e251279a94b172a6b263290e7/xsdata-26.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/6d/c6/6b726ddf4c3ac5a123f285c3650fa8268902c28ea541a0282867f1336e65/zarr-3.3.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+packages:
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+build_number: 20
+sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+md5: a9f577daf3de00bca7c3c76c0ecbd1de
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgomp >=7.5.0
+constrains:
+- openmp_impl <0.0a0
+license: BSD-3-Clause
+license_family: BSD
+purls: []
+size: 28948
+timestamp: 1770939786096
+- pypi: https://files.pythonhosted.org/packages/58/0a/a10b45aab35b175aded078a462dc8d0c698f5b13946e7cb0869097b78bb6/absl_py-2.5.0-py3-none-any.whl
+name: absl-py
+version: 2.5.0
+sha256: 0f17b89f2a4eaaedc4f28c622998aa690564b3012a396a4ffad0821007fe03ba
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/30/c5/6290519dec32f3cdf6827e3bbcbf7a9f4fb29a55a9204199901fed69957b/aiobotocore-3.9.0-py3-none-any.whl
+name: aiobotocore
+version: 3.9.0
+sha256: 7354659eac9ba6034675b3ea178330b7de97c45989d6fda1bf01d3da167b6135
+requires_dist:
+- aiohttp>=3.14.0,<4.0.0
+- aioitertools>=0.5.1,<1.0.0
+- botocore>=1.43.3,<1.43.57
+- jmespath>=0.7.1,<2.0.0
+- multidict>=6.0.0,<7.0.0
+- python-dateutil>=2.1,<3.0.0
+- typing-extensions>=4.14.0,<5.0.0 ; python_full_version < '3.11'
+- wrapt>=1.10.10,<3.0.0
+- anyio>=4.11.0,<5 ; extra == 'httpx'
+- httpx>=0.25.1,<0.29 ; extra == 'httpx'
+- anyio>=4.11.0,<5 ; extra == 'httpx2'
+- httpx2>=2.0,<3.0.0 ; extra == 'httpx2'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl
+name: aiohappyeyeballs
+version: 2.7.1
+sha256: 9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/52/b7/7cd31f29d6055bd711ae6e669367fba6f5ae9de463910a793e30556a8db7/aiohttp-3.14.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+name: aiohttp
+version: 3.14.3
+sha256: 543906c127fb1d929b95076db19b83fa2d46751006ff1e23b093aa5ac4d8db42
+requires_dist:
+- aiohappyeyeballs>=2.5.0
+- aiosignal>=1.4.0
+- async-timeout>=4.0,<6.0 ; python_full_version < '3.11'
+- attrs>=17.3.0
+- frozenlist>=1.1.1
+- multidict>=4.5,<7.0
+- propcache>=0.2.0
+- typing-extensions>=4.4 ; python_full_version < '3.13'
+- yarl>=1.17.0,<2.0
+- aiodns>=3.3.0 ; sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
+- brotli>=1.2 ; platform_python_implementation == 'CPython' and sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
+- brotlicffi>=1.2 ; platform_python_implementation != 'CPython' and extra == 'speedups'
+- backports-zstd ; python_full_version < '3.14' and platform_python_implementation == 'CPython' and sys_platform != 'android' and sys_platform != 'ios' and extra == 'speedups'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/10/a1/510b0a7fadc6f43a6ce50152e69dbd86415240835868bb0bd9b5b88b1e06/aioitertools-0.13.0-py3-none-any.whl
+name: aioitertools
+version: 0.13.0
+sha256: 0be0292b856f08dfac90e31f4739432f4cb6d7520ab9eb73e143f4f2fa5259be
+requires_dist:
+- typing-extensions>=4.0 ; python_full_version < '3.10'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl
+name: aiosignal
+version: 1.4.0
+sha256: 053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e
+requires_dist:
+- frozenlist>=1.1.0
+- typing-extensions>=4.2 ; python_full_version < '3.13'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/94/ad/33a5291066c4d51be58a8c537545402605feaa9fca49ff51ada6912d0234/anndata-0.13.3.post0-py3-none-any.whl
+name: anndata
+version: 0.13.3.post0
+sha256: 9e5eab0abadff2e97e9ea913d7f234c50bb6bea14e27acf7a5ecf14373e7e18b
+requires_dist:
+- array-api-compat>=1.7.1
+- h5py>=3.11
+- legacy-api-wrap
+- natsort
+- numpy>=2.1
+- packaging>=24.2
+- pandas>=2.3
+- scipy>=1.14,!=1.17.0
+- scverse-misc[settings]>=0.1.0
+- typing-extensions>=4.16 ; python_full_version < '3.15'
+- zarr>=3.1
+- cupy-cuda11x ; extra == 'cu11'
+- cupy-cuda12x ; extra == 'cu12'
+- cupy-cuda13x ; extra == 'cu13'
+- dask[array]>=2024.5.1,!=2024.8.*,!=2024.9.*,!=2025.2.*,!=2025.3.*,!=2025.4.*,!=2025.5.*,!=2025.6.*,!=2025.7.*,!=2025.8.* ; extra == 'dask'
+- cupy ; extra == 'gpu'
+- aiohttp ; extra == 'lazy'
+- dask[array]>=2024.5.1,!=2024.8.*,!=2024.9.*,!=2025.2.*,!=2025.3.*,!=2025.4.*,!=2025.5.*,!=2025.6.*,!=2025.7.*,!=2025.8.* ; extra == 'lazy'
+- requests ; extra == 'lazy'
+- xarray>=2025.6.1 ; extra == 'lazy'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl
+name: annotated-doc
+version: 0.0.5
+sha256: 117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl
+name: annotated-types
+version: 0.8.0
+sha256: f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/69/21/3587d7b32dfade1532d9cbb67291cb26f4353c296cadcda6767bd62458d3/annsel-0.1.3-py3-none-any.whl
+name: annsel
+version: 0.1.3
+sha256: 16eb2d520be086f8e9c8e04cf3e75a5f29814d72f602b48166c10af82bc1eb9d
+requires_dist:
+- anndata>=0.12
+- more-itertools>=10.7
+- narwhals[pandas]>=2.14
+- pooch>=1.8.2
+- session-info2
+- tqdm>=4
+- universal-pathlib>=0.2
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/86/16/1a8fd2b19544b84575cf84ef7aa3ad4c173b756d5f087c91f85d1b295777/array_api_compat-1.15.0-py3-none-any.whl
+name: array-api-compat
+version: 1.15.0
+sha256: 7b1b9c53269061403fd5f45a8de349f16e7887653328bfa0c5f2d45299ff0a8e
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl
+name: astunparse
+version: 1.6.3
+sha256: c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8
+requires_dist:
+- wheel>=0.23.0,<1.0
+- six>=1.6.1,<2.0
+- pypi: https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl
+name: attrs
+version: 26.1.0
+sha256: c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/5c/cd/86fe9e659e9699f62f8dd5ecd8c6725474334b23cab8aa71d82b5f56f1a4/botocore-1.43.56-py3-none-any.whl
+name: botocore
+version: 1.43.56
+sha256: aafc741f1b10f6fd63253eaf6ea029680c1ff436d87e1b8969d62aefa0c76976
+requires_dist:
+- jmespath>=0.7.1,<2.0.0
+- python-dateutil>=2.1,<3.0.0
+- urllib3>=1.25.4,!=2.2.0,<3
+- awscrt==0.36.0 ; extra == 'crt'
+requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+md5: e675fabcf81499adc7edf58124fb1e01
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: bzip2-1.0.6
+license_family: BSD
+purls: []
+size: 257808
+timestamp: 1785906269155
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+md5: 0f51e2391ade309db462a55611263e9c
+depends:
+- __unix
+license: ISC
+purls: []
+size: 131780
+timestamp: 1784754889428
+- pypi: https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl
+name: certifi
+version: 2026.7.22
+sha256: 62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775
+requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+name: charset-normalizer
+version: 3.5.1
+sha256: b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08
+requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl
+name: click
+version: 8.5.0
+sha256: 255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl
+name: cloudpickle
+version: 3.1.2
+sha256: 9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a
+requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/1b/24/e95471ae93c08d3606c9c7343cf65d490f154daa88b50581957a0aa780f4/colorcet-3.2.1-py3-none-any.whl
+name: colorcet
+version: 3.2.1
+sha256: 3f6fde13cef2169222dd5fe2a2bf847c02d644470fdf167ed566f6421df470f7
+requires_dist:
+- pre-commit ; extra == 'tests'
+- pytest>=2.8.5 ; extra == 'tests'
+- pytest-cov ; extra == 'tests'
+- packaging ; extra == 'tests'
+- colorcet[tests] ; extra == 'tests-extra'
+- pytest-mpl ; extra == 'tests-extra'
+- numpy ; extra == 'examples'
+- holoviews ; extra == 'examples'
+- matplotlib ; extra == 'examples'
+- bokeh ; extra == 'examples'
+- colorcet[examples] ; extra == 'tests-examples'
+- nbval ; extra == 'tests-examples'
+- colorcet[examples] ; extra == 'doc'
+- nbsite>=0.8.4 ; extra == 'doc'
+- sphinx-copybutton ; extra == 'doc'
+- colorcet[tests] ; extra == 'all'
+- colorcet[tests-extra] ; extra == 'all'
+- colorcet[examples] ; extra == 'all'
+- colorcet[doc] ; extra == 'all'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+name: contourpy
+version: 1.3.3
+sha256: 4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1
+requires_dist:
+- numpy>=1.25
+- furo ; extra == 'docs'
+- sphinx>=7.2 ; extra == 'docs'
+- sphinx-copybutton ; extra == 'docs'
+- bokeh ; extra == 'bokeh'
+- selenium ; extra == 'bokeh'
+- contourpy[bokeh,docs] ; extra == 'mypy'
+- bokeh ; extra == 'mypy'
+- docutils-stubs ; extra == 'mypy'
+- mypy==1.17.0 ; extra == 'mypy'
+- types-pillow ; extra == 'mypy'
+- contourpy[test-no-images] ; extra == 'test'
+- matplotlib ; extra == 'test'
+- pillow ; extra == 'test'
+- pytest ; extra == 'test-no-images'
+- pytest-cov ; extra == 'test-no-images'
+- pytest-rerunfailures ; extra == 'test-no-images'
+- pytest-xdist ; extra == 'test-no-images'
+- wurlitzer ; extra == 'test-no-images'
+requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/b8/2a/d5a3434d86fb13522ee39fe1c4a68c11d5c5e2b93d762000557e139f7be9/csbdeep-0.8.2-py2.py3-none-any.whl
+name: csbdeep
+version: 0.8.2
+sha256: 5806b4ac2949c6a5737a789cf8897d7632cc9b6d0a323a12028ef165b99e5485
+requires_dist:
+- numpy
+- scipy
+- matplotlib
+- six
+- tifffile
+- tqdm
+- packaging
+- sphinx ; extra == 'docs'
+- sphinx-rtd-theme ; extra == 'docs'
+- pytest ; extra == 'test'
+- keras>=2.1.2,<2.4 ; extra == 'tf1'
+- protobuf<3.21 ; extra == 'tf1'
+- h5py<3 ; extra == 'tf1'
+- numpy<2 ; extra == 'tf1'
+requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
+name: cycler
+version: 0.12.1
+sha256: 85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30
+requires_dist:
+- ipython ; extra == 'docs'
+- matplotlib ; extra == 'docs'
+- numpydoc ; extra == 'docs'
+- sphinx ; extra == 'docs'
+- pytest ; extra == 'tests'
+- pytest-cov ; extra == 'tests'
+- pytest-xdist ; extra == 'tests'
+requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/f8/3a/4fc99e788bcfa1b3b3f21abf57da45898d807d007e7f6fd1c7300904eb70/dask-2026.8.0-py3-none-any.whl
+name: dask
+version: 2026.8.0
+sha256: ccc0c83a189b0398602435189771d28dad7b5773b6089bb8dce14ae732dd782c
+requires_dist:
+- click>=8.1
+- cloudpickle>=3.0.0
+- fsspec>=2021.9.0
+- packaging>=20.0
+- partd>=1.4.0
+- pyyaml>=5.4.1
+- toolz>=0.12.0
+- importlib-metadata>=4.13.0 ; python_full_version < '3.12'
+- numpy>=1.24 ; extra == 'array'
+- dask[array] ; extra == 'dataframe'
+- pandas>=2.0 ; extra == 'dataframe'
+- pyarrow>=16.0 ; extra == 'dataframe'
+- distributed>=2026.8.0,<2026.8.1 ; extra == 'distributed'
+- bokeh>=3.1.0 ; extra == 'diagnostics'
+- jinja2>=2.10.3 ; extra == 'diagnostics'
+- dask[array,dataframe,diagnostics,distributed] ; extra == 'complete'
+- lz4>=4.3.2 ; extra == 'complete'
+- pandas[test] ; extra == 'test'
+- pytest ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- pytest-mock ; extra == 'test'
+- pytest-rerunfailures ; extra == 'test'
+- pytest-timeout ; extra == 'test'
+- pytest-xdist ; extra == 'test'
+- pre-commit ; extra == 'test'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/3f/5b/15d6d6ff8697b188787609be059fe4f07f99fc00f43f68e9e1540fa8733e/dask_image-2026.5.0-py3-none-any.whl
+name: dask-image
+version: 2026.5.0
+sha256: acf86cd7f0f1e97804198d30b7cc931efd29f9dec86c65ec004b50405c3f5227
+requires_dist:
+- dask[array]>=2024.4.1
+- numpy>=1.18
+- scipy>=1.7.0
+- pims>=0.4.1
+- tifffile>=2020.10.1
+- dask[dataframe]>=2024.4.1 ; extra == 'dataframe'
+- pandas>=2.0.0 ; extra == 'dataframe'
+- build>=1.2.1 ; extra == 'test'
+- coverage>=7.2.1 ; extra == 'test'
+- flake8>=6.0.0 ; extra == 'test'
+- flake8-pyproject ; extra == 'test'
+- pytest>=7.2.2 ; extra == 'test'
+- pytest-cov>=4.0.0 ; extra == 'test'
+- pytest-flake8>=1.1.1 ; extra == 'test'
+- pytest-timeout>=2.3.1 ; extra == 'test'
+- twine>=3.1.1 ; extra == 'test'
+- cupy>=9.0.0 ; extra == 'gpu'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/cb/41/247627c8b9fef5c605d00546b85771a8fe42975b9616a557cead5468789b/datashader-0.19.1-py3-none-any.whl
+name: datashader
+version: 0.19.1
+sha256: 7ce7154ff3ed070607f429355f57002fee5a17964e47c0b6447eeafe8cef9c82
+requires_dist:
+- colorcet
+- multipledispatch
+- numba
+- numpy
+- packaging
+- pandas
+- param
+- pyct
+- requests
+- scipy
+- toolz
+- xarray
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl
+name: deprecated
+version: 1.3.1
+sha256: 597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f
+requires_dist:
+- wrapt>=1.10,<3
+- inspect2 ; python_full_version < '3'
+- tox ; extra == 'dev'
+- pytest ; extra == 'dev'
+- pytest-cov ; extra == 'dev'
+- bump2version<1 ; extra == 'dev'
+- setuptools ; python_full_version >= '3.12' and extra == 'dev'
+requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+- pypi: https://files.pythonhosted.org/packages/28/d4/017e2d39d797eaa38a52b4459c8bea875d5e0ada335a62aafe98193041a6/distributed-2026.8.0-py3-none-any.whl
+name: distributed
+version: 2026.8.0
+sha256: 3bd8882861a2cf497453f28c6b61135fa8ef2bb1d6885ad3b9f27e887e9c0e01
+requires_dist:
+- click>=8.0
+- cloudpickle>=3.0.0
+- dask>=2026.8.0,<2026.8.1
+- jinja2>=2.10.3
+- locket>=1.0.0
+- msgpack>=1.0.2
+- packaging>=20.0
+- psutil>=5.8.0
+- pyyaml>=5.4.1
+- sortedcontainers>=2.0.5
+- tblib>=1.6.0,!=3.2.0,!=3.2.1
+- toolz>=0.12.0
+- tornado>=6.2.0
+- zict>=3.0.0
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
+name: donfig
+version: 0.8.1.post1
+sha256: 2a3175ce74a06109ff9307d90a230f81215cbac9a751f4d1c6194644b8204f9d
+requires_dist:
+- pyyaml
+- sphinx>=4.0.0 ; extra == 'docs'
+- numpydoc ; extra == 'docs'
+- pytest ; extra == 'docs'
+- cloudpickle ; extra == 'docs'
+- pytest ; extra == 'test'
+- cloudpickle ; extra == 'test'
+requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/be/54/f5add3c73052d18b1fda3eb5dd7a0ced1fccb3b425321c899a084063e406/fast_array_utils-1.5-py3-none-any.whl
+name: fast-array-utils
+version: '1.5'
+sha256: 08a349dc9cbcfaa59b98bf00e7aa36ef11ddef91128784a65d2eb63c4681b282
+requires_dist:
+- array-api-compat
+- numpy>=2
+- numba>=0.57 ; extra == 'accel'
+- dask>=2023.6.1 ; extra == 'dask'
+- dask>=2023.6.1 ; extra == 'full'
+- h5py ; extra == 'full'
+- numba>=0.57 ; extra == 'full'
+- scipy>=1.13 ; extra == 'full'
+- zarr ; extra == 'full'
+- scipy>=1.13 ; extra == 'sparse'
+- packaging ; extra == 'testing'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl
+name: flatbuffers
+version: 25.12.19
+sha256: 7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4
+- pypi: https://files.pythonhosted.org/packages/67/61/5af8df9c7c2c96bd1a2cb758b278d467300e5f4714769ba70e4351da1a4f/flowio-1.4.0.tar.gz
+name: flowio
+version: 1.4.0
+sha256: c205efcecd1da7da29a1a55c30e09daa7fc132b997cd88910ef06a490755ecf7
+requires_dist:
+- numpy>=1.19.3
+- pypi: https://files.pythonhosted.org/packages/dc/8f/e5f2906ea833d362916c64a2f6b1922a07b19442744fd3cd89563f429bff/fonttools-4.64.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+name: fonttools
+version: 4.64.0
+sha256: 66a83f93579fb3493e458c4449d1d566a7b2a1c7b19915cd0fa3c9b8b5a8540b
+requires_dist:
+- lxml>=4.0 ; extra == 'lxml'
+- brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'woff'
+- brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'woff'
+- zopfli>=0.1.4 ; extra == 'woff'
+- unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'unicode'
+- lz4>=1.7.4.2 ; extra == 'graphite'
+- scipy ; platform_python_implementation != 'PyPy' and extra == 'interpolatable'
+- munkres ; platform_python_implementation == 'PyPy' and extra == 'interpolatable'
+- pycairo ; extra == 'interpolatable'
+- matplotlib ; extra == 'plot'
+- sympy ; extra == 'symfont'
+- xattr ; sys_platform == 'darwin' and extra == 'type1'
+- skia-pathops>=0.5.0 ; extra == 'pathops'
+- uharfbuzz>=0.45.0 ; extra == 'repacker'
+- lxml>=4.0 ; extra == 'all'
+- brotli>=1.0.1 ; platform_python_implementation == 'CPython' and extra == 'all'
+- brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'all'
+- zopfli>=0.1.4 ; extra == 'all'
+- unicodedata2>=17.0.0 ; python_full_version < '3.15' and extra == 'all'
+- lz4>=1.7.4.2 ; extra == 'all'
+- scipy ; platform_python_implementation != 'PyPy' and extra == 'all'
+- munkres ; platform_python_implementation == 'PyPy' and extra == 'all'
+- pycairo ; extra == 'all'
+- matplotlib ; extra == 'all'
+- sympy ; extra == 'all'
+- xattr ; sys_platform == 'darwin' and extra == 'all'
+- skia-pathops>=0.5.0 ; extra == 'all'
+- uharfbuzz>=0.45.0 ; extra == 'all'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/fc/75/0576b03f7889ad25b5385b4f6c69e0543713425a6f193b056c9b0a2e65ce/formulaic-1.2.2-py3-none-any.whl
+name: formulaic
+version: 1.2.2
+sha256: 0f84ff49e3fc9dc0e68ab08a0a9427874021aa6c558e66b44dc634a35739b09b
+requires_dist:
+- interface-meta>=1.2.0
+- narwhals>=1.17
+- numpy>=1.20.0
+- pandas>=1.3
+- scipy>=1.6
+- typing-extensions>=4.2.0
+- wrapt>=1.0 ; python_full_version < '3.13'
+- wrapt>=1.17.0rc1 ; python_full_version >= '3.13'
+- pyarrow>=1 ; extra == 'arrow'
+- sympy>=1.3,!=1.10 ; extra == 'calculus'
+- polars>=1 ; extra == 'polars'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+name: frozenlist
+version: 1.8.0
+sha256: 494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl
+name: fsspec
+version: 2026.7.0
+sha256: b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279
+requires_dist:
+- adlfs ; extra == 'abfs'
+- adlfs ; extra == 'adl'
+- pyarrow>=1 ; extra == 'arrow'
+- dask ; extra == 'dask'
+- distributed ; extra == 'dask'
+- pre-commit ; extra == 'dev'
+- ruff>=0.5 ; extra == 'dev'
+- numpydoc ; extra == 'doc'
+- sphinx ; extra == 'doc'
+- sphinx-design ; extra == 'doc'
+- sphinx-rtd-theme ; extra == 'doc'
+- yarl ; extra == 'doc'
+- dropbox ; extra == 'dropbox'
+- dropboxdrivefs ; extra == 'dropbox'
+- requests ; extra == 'dropbox'
+- adlfs ; extra == 'full'
+- aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'full'
+- dask ; extra == 'full'
+- distributed ; extra == 'full'
+- dropbox ; extra == 'full'
+- dropboxdrivefs ; extra == 'full'
+- fusepy ; extra == 'full'
+- gcsfs>=2026.4.0 ; extra == 'full'
+- libarchive-c ; extra == 'full'
+- ocifs ; extra == 'full'
+- panel ; extra == 'full'
+- paramiko ; extra == 'full'
+- pyarrow>=1 ; extra == 'full'
+- pygit2 ; extra == 'full'
+- requests ; extra == 'full'
+- s3fs>=2026.6.0 ; extra == 'full'
+- smbprotocol ; extra == 'full'
+- tqdm ; extra == 'full'
+- fusepy ; extra == 'fuse'
+- gcsfs>=2026.4.0 ; extra == 'gcs'
+- pygit2 ; extra == 'git'
+- requests ; extra == 'github'
+- gcsfs>=2026.4.0 ; extra == 'gs'
+- panel ; extra == 'gui'
+- pyarrow>=1 ; extra == 'hdfs'
+- aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'http'
+- libarchive-c ; extra == 'libarchive'
+- ocifs ; extra == 'oci'
+- s3fs>=2026.6.0 ; extra == 's3'
+- paramiko ; extra == 'sftp'
+- smbprotocol ; extra == 'smb'
+- paramiko ; extra == 'ssh'
+- aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'test'
+- numpy ; extra == 'test'
+- pytest ; extra == 'test'
+- pytest-asyncio!=0.22.0 ; extra == 'test'
+- pytest-benchmark ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- pytest-mock ; extra == 'test'
+- pytest-recording ; extra == 'test'
+- pytest-rerunfailures ; extra == 'test'
+- requests ; extra == 'test'
+- aiobotocore>=2.5.4,<3.0.0 ; extra == 'test-downstream'
+- dask[dataframe,test] ; extra == 'test-downstream'
+- moto[server]>4,<5 ; extra == 'test-downstream'
+- pytest-timeout ; extra == 'test-downstream'
+- xarray ; extra == 'test-downstream'
+- adlfs ; extra == 'test-full'
+- aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'test-full'
+- backports-zstd ; python_full_version < '3.14' and extra == 'test-full'
+- cloudpickle ; extra == 'test-full'
+- dask ; extra == 'test-full'
+- distributed ; extra == 'test-full'
+- dropbox ; extra == 'test-full'
+- dropboxdrivefs ; extra == 'test-full'
+- fastparquet ; extra == 'test-full'
+- fusepy ; extra == 'test-full'
+- gcsfs>=2026.4.0 ; extra == 'test-full'
+- jinja2 ; extra == 'test-full'
+- kerchunk ; extra == 'test-full'
+- libarchive-c ; extra == 'test-full'
+- lz4 ; extra == 'test-full'
+- notebook ; extra == 'test-full'
+- numpy ; extra == 'test-full'
+- ocifs ; extra == 'test-full'
+- pandas<3.0.0 ; extra == 'test-full'
+- panel ; extra == 'test-full'
+- paramiko ; extra == 'test-full'
+- pyarrow>=1 ; extra == 'test-full'
+- pyftpdlib ; extra == 'test-full'
+- pygit2 ; extra == 'test-full'
+- pytest ; extra == 'test-full'
+- pytest-asyncio!=0.22.0 ; extra == 'test-full'
+- pytest-benchmark ; extra == 'test-full'
+- pytest-cov ; extra == 'test-full'
+- pytest-mock ; extra == 'test-full'
+- pytest-recording ; extra == 'test-full'
+- pytest-rerunfailures ; extra == 'test-full'
+- python-snappy ; extra == 'test-full'
+- requests ; extra == 'test-full'
+- s3fs>=2026.6.0 ; extra == 'test-full'
+- smbprotocol ; extra == 'test-full'
+- tqdm ; extra == 'test-full'
+- urllib3 ; extra == 'test-full'
+- zarr<3.2.0 ; extra == 'test-full'
+- zstandard ; python_full_version < '3.14' and extra == 'test-full'
+- tqdm ; extra == 'tqdm'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/1d/33/f1c6a276de27b7d7339a34749cc33fa87f077f921969c47185d34a887ae2/gast-0.7.0-py3-none-any.whl
+name: gast
+version: 0.7.0
+sha256: 99cbf1365633a74099f69c59bd650476b96baa5ef196fec88032b00b31ba36f7
+requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+- pypi: https://files.pythonhosted.org/packages/59/a8/bd530cc264e62ddbc1d1bb7225823992e6f2432c664693e9281bb6b9c359/geopandas-1.1.4-py3-none-any.whl
+name: geopandas
+version: 1.1.4
+sha256: 1a0c459cbdb1537cd154dafe6174be20d1760844b7f1c967dc8520b180f2e773
+requires_dist:
+- numpy>=1.24
+- pyogrio>=0.7.2
+- packaging
+- pandas>=2.0.0
+- pyproj>=3.5.0
+- shapely>=2.0.0
+- psycopg[binary]>=3.1.0 ; extra == 'all'
+- sqlalchemy>=2.0 ; extra == 'all'
+- geopy ; extra == 'all'
+- matplotlib>=3.7 ; extra == 'all'
+- mapclassify>=2.5 ; extra == 'all'
+- xyzservices ; extra == 'all'
+- folium ; extra == 'all'
+- geoalchemy2 ; extra == 'all'
+- pyarrow>=10.0.0 ; extra == 'all'
+- scipy ; extra == 'all'
+- pointpats>=2.5.3 ; extra == 'all'
+- pytest>=3.1.0 ; extra == 'dev'
+- pytest-cov ; extra == 'dev'
+- pytest-xdist ; extra == 'dev'
+- codecov ; extra == 'dev'
+- pre-commit ; extra == 'dev'
+- ruff ; extra == 'dev'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+name: google-crc32c
+version: 1.8.0
+sha256: 14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl
+name: google-pasta
+version: 0.2.0
+sha256: b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed
+requires_dist:
+- six
+- pypi: https://files.pythonhosted.org/packages/bc/19/9fc702e31a631262d7a752fa699f6022821e707fefc8bff49b1550a57729/grpcio-1.83.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+name: grpcio
+version: 1.83.1
+sha256: 72578aa07a4008f17521ef52debcc3acfd1e2c5426243bc3ffb56a38bfe610b7
+requires_dist:
+- typing-extensions~=4.12
+- grpcio-tools>=1.83.1 ; extra == 'protobuf'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/86/f9/f00de11c82c88bfc1ef22633557bfba9e271e0cb3189ad704183fc4a2644/h5py-3.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+name: h5py
+version: 3.14.0
+sha256: 0cbd41f4e3761f150aa5b662df991868ca533872c95467216f2bec5fcad84882
+requires_dist:
+- numpy>=1.19.3
+requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+md5: 72a381cbad04f24b1c2a43ef707f45b4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: MIT
+license_family: MIT
+purls: []
+size: 14459115
+timestamp: 1786545741408
+- pypi: https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl
+name: idna
+version: '3.19'
+sha256: 815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4
+requires_dist:
+- ruff>=0.16.0 ; extra == 'all'
+- mypy>=1.11.2 ; extra == 'all'
+- ty>=0.0.37 ; extra == 'all'
+- pytest>=8.3.2 ; extra == 'all'
+- hypothesis>=6.141.1 ; extra == 'all'
+- coverage>=7.10.0 ; extra == 'all'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/7d/da/dd2867c25adbb41563720f14b5fc895c98bf88be682a3faff4f7b3118d2a/igraph-1.0.0-cp39-abi3-manylinux_2_28_x86_64.whl
+name: igraph
+version: 1.0.0
+sha256: 2d04c2c76f686fb1f554ee35dfd3085f5e73b7965ba6b4cf06d53e66b1955522
+requires_dist:
+- texttable>=1.6.2
+- cairocffi>=1.2.0 ; extra == 'cairo'
+- matplotlib>=3.6.0 ; platform_python_implementation != 'PyPy' and extra == 'matplotlib'
+- plotly>=5.3.0 ; extra == 'plotly'
+- cairocffi>=1.2.0 ; extra == 'plotting'
+- cairocffi>=1.2.0 ; extra == 'test'
+- networkx>=2.5 ; extra == 'test'
+- pytest>=7.0.1 ; extra == 'test'
+- pytest-timeout>=2.1.0 ; extra == 'test'
+- numpy>=1.19.0 ; platform_python_implementation != 'PyPy' and extra == 'test'
+- pandas>=1.1.0 ; platform_python_implementation != 'PyPy' and extra == 'test'
+- scipy>=1.5.0 ; platform_python_implementation != 'PyPy' and extra == 'test'
+- matplotlib>=3.6.0 ; platform_python_implementation != 'PyPy' and extra == 'test'
+- plotly>=5.3.0 ; extra == 'test'
+- pillow>=9 ; platform_python_implementation != 'PyPy' and extra == 'test'
+- cairocffi>=1.2.0 ; extra == 'test-win-arm64'
+- networkx>=2.5 ; extra == 'test-win-arm64'
+- pytest>=7.0.1 ; extra == 'test-win-arm64'
+- pytest-timeout>=2.1.0 ; extra == 'test-win-arm64'
+- cairocffi>=1.2.0 ; extra == 'test-musl'
+- networkx>=2.5 ; extra == 'test-musl'
+- pytest>=7.0.1 ; extra == 'test-musl'
+- pytest-timeout>=2.1.0 ; extra == 'test-musl'
+- sphinx>=7.0.0 ; extra == 'doc'
+- sphinx-rtd-theme>=1.3.0 ; extra == 'doc'
+- sphinx-gallery>=0.14.0 ; extra == 'doc'
+- pydoctor>=23.4.0 ; extra == 'doc'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/67/1b/0771f9b93a8f43b1e98a20d33fab02a6eceb8bb75c32764b5d47ee4db36f/imagecodecs-2026.8.16-cp312-abi3-manylinux_2_28_x86_64.whl
+name: imagecodecs
+version: 2026.8.16
+sha256: c1068e0db9bc09cbd32510e543caed50f231096aecbb4c9cf7bcfbd2ffc53a50
+requires_dist:
+- numpy>=2.1
+- matplotlib ; extra == 'all'
+- tifffile ; extra == 'all'
+- numcodecs ; extra == 'all'
+- pytest ; extra == 'test'
+- pytest-run-parallel ; extra == 'test'
+- tifffile ; extra == 'test'
+- czifile ; extra == 'test'
+- backports-zstd ; extra == 'test'
+- blosc ; extra == 'test'
+- blosc2 ; extra == 'test'
+- brotli ; extra == 'test'
+- lz4 ; extra == 'test'
+- pyliblzfse ; extra == 'test'
+- python-lzf ; extra == 'test'
+- python-snappy ; extra == 'test'
+- bitshuffle ; extra == 'test'
+- zopflipy ; extra == 'test'
+- zarr ; extra == 'test'
+- numcodecs ; extra == 'test'
+- kerchunk ; extra == 'test'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/3e/2d/ca050652104bab2cf55e569db2a178b1b61cb041fef28307f2db383f6d9f/imageio-2.37.4-py3-none-any.whl
+name: imageio
+version: 2.37.4
+sha256: 1ab2e22c8debf700f24c3ac43e8f95f3b3a8110c83b93411e97b4b0b2cd1c7e6
+requires_dist:
+- numpy
+- pillow>=8.3.2
+- imageio-ffmpeg ; extra == 'ffmpeg'
+- psutil ; extra == 'ffmpeg'
+- fsspec[http] ; extra == 'freeimage'
+- pillow-heif ; extra == 'pillow-heif'
+- tifffile ; extra == 'tifffile'
+- av ; extra == 'pyav'
+- astropy ; extra == 'fits'
+- rawpy ; extra == 'rawpy'
+- numpy>2 ; extra == 'rawpy'
+- gdal ; extra == 'gdal'
+- itk ; extra == 'itk'
+- black ; extra == 'linting'
+- flake8 ; extra == 'linting'
+- pytest ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- fsspec[github] ; extra == 'test'
+- sphinx<6 ; extra == 'docs'
+- numpydoc ; extra == 'docs'
+- pydata-sphinx-theme ; extra == 'docs'
+- pytest ; extra == 'dev'
+- pytest-cov ; extra == 'dev'
+- fsspec[github] ; extra == 'dev'
+- black ; extra == 'dev'
+- flake8 ; extra == 'dev'
+- av ; extra == 'all-plugins'
+- astropy ; extra == 'all-plugins'
+- fsspec[http] ; extra == 'all-plugins'
+- imageio-ffmpeg ; extra == 'all-plugins'
+- numpy>2 ; extra == 'all-plugins'
+- pillow-heif ; extra == 'all-plugins'
+- psutil ; extra == 'all-plugins'
+- rawpy ; extra == 'all-plugins'
+- tifffile ; extra == 'all-plugins'
+- fsspec[http] ; extra == 'all-plugins-pypy'
+- imageio-ffmpeg ; extra == 'all-plugins-pypy'
+- pillow-heif ; extra == 'all-plugins-pypy'
+- psutil ; extra == 'all-plugins-pypy'
+- astropy ; extra == 'full'
+- av ; extra == 'full'
+- black ; extra == 'full'
+- flake8 ; extra == 'full'
+- fsspec[github,http] ; extra == 'full'
+- imageio-ffmpeg ; extra == 'full'
+- numpydoc ; extra == 'full'
+- numpy>2 ; extra == 'full'
+- pillow-heif ; extra == 'full'
+- psutil ; extra == 'full'
+- pydata-sphinx-theme ; extra == 'full'
+- pytest ; extra == 'full'
+- pytest-cov ; extra == 'full'
+- rawpy ; extra == 'full'
+- sphinx<6 ; extra == 'full'
+- tifffile ; extra == 'full'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/a1/d3/20a61a248feb1249cd81f83ce731f0bdf5170ed96a08a298f7081cda9e90/interface_meta-2.0.1-py3-none-any.whl
+name: interface-meta
+version: 2.0.1
+sha256: f38016bef9a4429b6d0792d809be7b65e9781820c674bf7f463999086b6e6323
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl
+name: jinja2
+version: 3.1.6
+sha256: 85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
+requires_dist:
+- markupsafe>=2.0
+- babel>=2.7 ; extra == 'i18n'
+requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl
+name: jmespath
+version: 1.1.0
+sha256: a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/18/53/84099323c2ec4be98d935f63c033ac4151ee83836ca1050ede3b3aadf155/joblib-1.6.0-py3-none-any.whl
+name: joblib
+version: 1.6.0
+sha256: 3dbbf9f6e4b592a2357b854608e980fe6390d131d7a82f011a377ef2ebef7aba
+requires_dist:
+- cloudpickle>=3.0
+- distributed ; extra == 'test'
+- lz4 ; extra == 'test'
+- numpy ; extra == 'test'
+- memory-profiler ; extra == 'test'
+- pytest ; extra == 'test'
+- pytest-asyncio ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- pytest-run-parallel ; extra == 'test'
+- pytest-timeout ; extra == 'test'
+- threadpoolctl ; extra == 'test'
+- distributed ; extra == 'docs'
+- lz4 ; extra == 'docs'
+- numpy ; extra == 'docs'
+- numpydoc ; extra == 'docs'
+- matplotlib ; extra == 'docs'
+- pandas ; extra == 'docs'
+- psutil ; extra == 'docs'
+- sphinx ; extra == 'docs'
+- pydata-sphinx-theme ; extra == 'docs'
+- sphinx-gallery ; extra == 'docs'
+- sphinx-copybutton ; extra == 'docs'
+- sphinx-design ; extra == 'docs'
+- tqdm ; extra == 'docs'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8d/b3/c9b848bbdba18e765a8051917c0cc82585b64278ce87895f2e521a27438f/keras-3.15.1-py3-none-any.whl
+name: keras
+version: 3.15.1
+sha256: 836460e480930acbd19bb7a17e62f9ecad40e8a9af9a651fc8d0586a96d27e20
+requires_dist:
+- absl-py
+- numpy
+- rich
+- namex
+- h5py
+- optree
+- ml-dtypes
+- packaging
+requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/fc/f4/dadfec469313c7f428efa7e84b4aba9732f813c13ea7131a24b7b008ef57/kiwisolver-1.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+name: kiwisolver
+version: 1.5.1
+sha256: 34633ecf50d16187ab8e5528b7a2530f2feb4e23f300db4672538b51cfc5cd38
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl
+name: lazy-loader
+version: '0.5'
+sha256: ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005
+requires_dist:
+- packaging
+- pytest>=8.0 ; extra == 'test'
+- pytest-cov>=5.0 ; extra == 'test'
+- coverage[toml]>=7.2 ; extra == 'test'
+- pre-commit==4.3.0 ; extra == 'lint'
+- changelist==0.5 ; extra == 'dev'
+- spin==0.15 ; extra == 'dev'
+requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+md5: 449500f2c089da11c40f5c21312e3e07
+depends:
+- __glibc >=2.17,<3.0.a0
+- zstd >=1.5.7,<1.6.0a0
+constrains:
+- binutils_impl_linux-64 2.46.1
+license: GPL-3.0-only
+license_family: GPL
+purls: []
+size: 745303
+timestamp: 1784214507189
+- pypi: https://files.pythonhosted.org/packages/41/5b/058db09c45ba58a7321bdf2294cae651b37d6fec68117265af90cde043b0/legacy_api_wrap-1.5-py3-none-any.whl
+name: legacy-api-wrap
+version: '1.5'
+sha256: 5a8ea50e3e3bcbcdec3447b77034fd0d32cb2cf4089db799238708e4d7e0098d
+requires_dist:
+- anyconfig[toml]>=0.14 ; extra == 'test'
+- coverage ; extra == 'test'
+- coverage-rich ; extra == 'test'
+- pytest ; extra == 'test'
+- typer<0.14 ; extra == 'test'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/1d/fc/716c1e62e512ef1c160e7984a73a5fc7df45166f2ff3f254e71c58076f7c/libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl
+name: libclang
+version: 18.1.1
+sha256: c533091d8a3bbf7460a00cb6c1a71da93bffe148f172c7d03b1c31fbf8aa2a0b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+md5: b24d3c612f71e7aa74158d92106318b2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- expat 2.8.1.*
+license: MIT
+license_family: MIT
+purls: []
+size: 77856
+timestamp: 1781203599810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+md5: 6525a0b06aa4fd390795f0740636a9dd
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: MIT
+license_family: MIT
+purls: []
+size: 68004
+timestamp: 1787753412298
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+md5: cba14d01083fc62ffd32c24d7d390633
+depends:
+- __glibc >=2.17,<3.0.a0
+- _openmp_mutex >=4.5
+constrains:
+- libgcc-ng ==16.2.0=*_4
+- libgomp 16.2.0 he0feb66_4
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+purls: []
+size: 1058083
+timestamp: 1787618680111
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+md5: 89d2c1231f47bd818f5d624b9411459d
+depends:
+- __glibc >=2.17,<3.0.a0
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+purls: []
+size: 639968
+timestamp: 1787618616266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+constrains:
+- xz 5.8.3.*
+license: 0BSD
+purls: []
+size: 112995
+timestamp: 1786348617826
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+md5: d864d34357c3b65a4b731f78c0801dc4
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=13
+license: LGPL-2.1-only
+license_family: GPL
+purls: []
+size: 33731
+timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.12.14-h0c77377_3_cpython.conda
+build_number: 3
+sha256: 6be16a4906d83eb8e9e04375d524f339f426a847cffd294f1ceb0611988dc17a
+md5: d247b7632f09324c11f24b5270361385
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- libstdcxx >=15
+license: Python-2.0
+purls: []
+size: 8770625
+timestamp: 1788392466381
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+md5: e72bbec309c2b0f37823ee7d4fabfcd3
+depends:
+- __glibc >=2.17,<3.0.a0
+- icu >=78.3,<79.0a0
+- libgcc >=15
+- libzlib >=1.3.2,<2.0a0
+license: blessing
+purls: []
+size: 974348
+timestamp: 1787051145557
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc 16.2.0 ha9f2e26_4
+constrains:
+- libstdcxx-ng ==16.2.0=*_4
+license: GPL-3.0-only WITH GCC-exception-3.1
+license_family: GPL
+purls: []
+size: 6613148
+timestamp: 1787618704262
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+md5: 74a0a409d9f4561265d36b789d3f398a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+license: BSD-3-Clause
+license_family: BSD
+purls: []
+size: 39998
+timestamp: 1788347719520
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.38-h280c20c_0.conda
+sha256: f7e9292dd219a6435bbb1223da9586c3e70d66d169c5a92f08db3f2127df04e9
+md5: f7a7ff5a6ab331e037abd34f379a631d
+depends:
+- libgcc >=14
+- __glibc >=2.17,<3.0.a0
+license: LGPL-2.1-or-later
+purls: []
+size: 101957
+timestamp: 1785887123445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+md5: 0de0122d9570a8ab637c6b73db268389
+depends:
+- __glibc >=2.17,<3.0.a0
+constrains:
+- zlib 1.3.2 *_3
+license: Zlib
+license_family: Other
+purls: []
+size: 63713
+timestamp: 1785362952714
+- pypi: https://files.pythonhosted.org/packages/be/3c/e97f69c62a2d972066d9a2612ce1f3de313035ac897a5b9f787cad8b55f7/llvmlite-0.49.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+name: llvmlite
+version: 0.49.0
+sha256: 6acba646d88abbc87d5c113a3d62c1fbf8b8fee11c6493f516803e30f21ae870
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/db/bc/83e112abc66cd466c6b83f99118035867cecd41802f8d044638aa78a106e/locket-1.0.0-py2.py3-none-any.whl
+name: locket
+version: 1.0.0
+sha256: b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3
+requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+- pypi: https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl
+name: markdown-it-py
+version: 4.2.0
+sha256: 9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a
+requires_dist:
+- mdurl~=0.1
+- psutil ; extra == 'benchmarking'
+- pytest ; extra == 'benchmarking'
+- pytest-benchmark ; extra == 'benchmarking'
+- commonmark~=0.9 ; extra == 'compare'
+- markdown~=3.4 ; extra == 'compare'
+- mistletoe~=1.0 ; extra == 'compare'
+- mistune~=3.0 ; extra == 'compare'
+- panflute~=2.3 ; extra == 'compare'
+- markdown-it-pyrs ; extra == 'compare'
+- linkify-it-py>=1,<3 ; extra == 'linkify'
+- mdit-py-plugins>=0.5.0 ; extra == 'plugins'
+- gprof2dot ; extra == 'profiling'
+- mdit-py-plugins>=0.5.0 ; extra == 'rtd'
+- myst-parser ; extra == 'rtd'
+- pyyaml ; extra == 'rtd'
+- sphinx ; extra == 'rtd'
+- sphinx-copybutton ; extra == 'rtd'
+- sphinx-design ; extra == 'rtd'
+- sphinx-book-theme~=1.0 ; extra == 'rtd'
+- jupyter-sphinx ; extra == 'rtd'
+- ipykernel ; extra == 'rtd'
+- coverage ; extra == 'testing'
+- pytest ; extra == 'testing'
+- pytest-cov ; extra == 'testing'
+- pytest-regressions ; extra == 'testing'
+- pytest-timeout ; extra == 'testing'
+- requests ; extra == 'testing'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+name: markupsafe
+version: 3.0.3
+sha256: d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/c9/cf/b4ad2cc81b6672ea29ea04e64e350a9f9b493b0908ccd884c67eeff8f7b2/matplotlib-3.11.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+name: matplotlib
+version: 3.11.1
+sha256: ba8f811b8ddfac493734d6af0b2dff96919d0c28ca0d641858dab4262777c6ea
+requires_dist:
+- contourpy>=1.0.1
+- cycler>=0.10
+- fonttools>=4.28.2
+- kiwisolver>=1.3.1
+- numpy>=1.25
+- packaging>=20.0
+- pillow>=9
+- pyparsing>=3
+- python-dateutil>=2.7
+requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/a8/c0/2dfab7b319dabe23f5a7b515a797c74b501d15c72e7a03837cf0cf779b9e/matplotlib_scalebar-0.9.0-py3-none-any.whl
+name: matplotlib-scalebar
+version: 0.9.0
+sha256: 5140525cd4e0c60bcade541b86571dabaf446fa69192530bd82d60b54601aa79
+requires_dist:
+- matplotlib
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+name: mdurl
+version: 0.1.2
+sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
+requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/c7/f9/7d76c1eae866f5d4636401b31b6d6dd90e4b4ced1fa7cfdfcca9c60e4bd3/ml_dtypes-0.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+name: ml-dtypes
+version: 0.6.0
+sha256: 3b4a480aa8fd54a1805b8ac10f3f91763926a74f73c0c364c10f9231854f4170
+requires_dist:
+- numpy>=2.0.0
+- numpy>=2.1.0 ; python_full_version >= '3.13'
+- numpy>=2.3.0 ; python_full_version >= '3.14'
+- absl-py ; extra == 'dev'
+- pytest ; extra == 'dev'
+- pytest-xdist ; extra == 'dev'
+- pylint>=2.6.0 ; extra == 'dev'
+- pyink ; extra == 'dev'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl
+name: more-itertools
+version: 11.1.0
+sha256: 4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/41/f0/29f591bea185616cf417645ac03bd3ad9b317483ad8572160e325f7fe777/msgpack-1.2.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+name: msgpack
+version: 1.2.2
+sha256: 77c2e018417dc1d66f235e383877ee885b60ade9d29e494dd581e08af2cb1923
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+name: multidict
+version: 6.7.1
+sha256: bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961
+requires_dist:
+- typing-extensions>=4.1.0 ; python_full_version < '3.11'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
+name: multipledispatch
+version: 1.0.0
+sha256: 0c53cd8b077546da4e48869f49b13164bebafd0c2a5afceb6bb6a316e7fb46e4
+- pypi: https://files.pythonhosted.org/packages/01/a7/fec56dbac873a18930b2127d400794a91dd53898bff811aa4802ddbbfac9/multiscale_spatial_image-2.0.3-py3-none-any.whl
+name: multiscale-spatial-image
+version: 2.0.3
+sha256: 8b20d36e90a104083fe14f5466d582eea453c213d1a368d7e7435b3e13445f61
+requires_dist:
+- dask
+- numpy
+- python-dateutil
+- spatial-image>=1.2.2
+- xarray-dataclass>=3.0.0
+- xarray>=2025.1.2
+- zarr
+- dask-image ; extra == 'dask-image'
+- pyimagej ; extra == 'imagej'
+- itk-filtering>=5.3.0 ; extra == 'itk'
+- matplotlib>=3.9.2,<4 ; extra == 'notebooks'
+- ome-types>=0.5.1.post1,<0.6 ; extra == 'notebooks'
+- tqdm>=4.66.4,<5 ; extra == 'notebooks'
+- fsspec ; extra == 'test'
+- jsonschema ; extra == 'test'
+- nbmake ; extra == 'test'
+- pooch ; extra == 'test'
+- pytest ; extra == 'test'
+- pytest-mypy ; extra == 'test'
+- urllib3 ; extra == 'test'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b2/bc/465daf1de06409cdd4532082806770ee0d8d7df434da79c76564d0f69741/namex-0.1.0-py3-none-any.whl
+name: namex
+version: 0.1.0
+sha256: e2012a474502f1e2251267062aae3114611f07df4224b6e06334c57b0f2ce87c
+- pypi: https://files.pythonhosted.org/packages/eb/dc/55481808fd70ef1567cf13540ffd4702af3f74b112e35427564b03f79c2d/narwhals-2.25.0-py3-none-any.whl
+name: narwhals
+version: 2.25.0
+sha256: 1f0f403e8c7e4463cde9bfe78b12fdd809e3ae3dda6d9b2f802934fb9c7a6a8f
+requires_dist:
+- cudf-cu12>=24.10.0 ; sys_platform == 'linux' and extra == 'cudf'
+- dask[dataframe]>=2024.8 ; extra == 'dask'
+- duckdb>=1.1 ; extra == 'duckdb'
+- ibis-framework>=6.0.0 ; extra == 'ibis'
+- packaging>=21.3 ; extra == 'ibis'
+- pyarrow-hotfix>=0.7 ; extra == 'ibis'
+- modin>=0.22.0 ; extra == 'modin'
+- pandas>=1.3.4 ; extra == 'pandas'
+- polars>=0.20.4 ; extra == 'polars'
+- pyarrow>=13.0.0 ; extra == 'pyarrow'
+- pyspark>=3.5.0 ; extra == 'pyspark'
+- pyspark[connect]>=3.5.0 ; extra == 'pyspark-connect'
+- narwhals[duckdb] ; extra == 'sql'
+- sqlparse>=0.5.5 ; extra == 'sql'
+- sqlframe>=3.22.0,!=3.39.3 ; extra == 'sqlframe'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
+name: natsort
+version: 8.4.0
+sha256: 4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c
+requires_dist:
+- fastnumbers>=2.0.0 ; extra == 'fast'
+- pyicu>=1.0.0 ; extra == 'icu'
+requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+md5: ee6c0cd80a60961a1f48aa3e0b91f986
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+license: X11 AND BSD-3-Clause
+purls: []
+size: 911196
+timestamp: 1786355078102
+- pypi: https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl
+name: networkx
+version: 3.6.1
+sha256: d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762
+requires_dist:
+- asv ; extra == 'benchmarking'
+- virtualenv ; extra == 'benchmarking'
+- numpy>=1.25 ; extra == 'default'
+- scipy>=1.11.2 ; extra == 'default'
+- matplotlib>=3.8 ; extra == 'default'
+- pandas>=2.0 ; extra == 'default'
+- pre-commit>=4.1 ; extra == 'developer'
+- mypy>=1.15 ; extra == 'developer'
+- sphinx>=8.0 ; extra == 'doc'
+- pydata-sphinx-theme>=0.16 ; extra == 'doc'
+- sphinx-gallery>=0.18 ; extra == 'doc'
+- numpydoc>=1.8.0 ; extra == 'doc'
+- pillow>=10 ; extra == 'doc'
+- texext>=0.6.7 ; extra == 'doc'
+- myst-nb>=1.1 ; extra == 'doc'
+- intersphinx-registry ; extra == 'doc'
+- osmnx>=2.0.0 ; extra == 'example'
+- momepy>=0.7.2 ; extra == 'example'
+- contextily>=1.6 ; extra == 'example'
+- seaborn>=0.13 ; extra == 'example'
+- cairocffi>=1.7 ; extra == 'example'
+- igraph>=0.11 ; extra == 'example'
+- scikit-learn>=1.5 ; extra == 'example'
+- iplotx>=0.9.0 ; extra == 'example'
+- lxml>=4.6 ; extra == 'extra'
+- pygraphviz>=1.14 ; extra == 'extra'
+- pydot>=3.0.1 ; extra == 'extra'
+- sympy>=1.10 ; extra == 'extra'
+- build>=0.10 ; extra == 'release'
+- twine>=4.0 ; extra == 'release'
+- wheel>=0.40 ; extra == 'release'
+- changelist==0.5 ; extra == 'release'
+- pytest>=7.2 ; extra == 'test'
+- pytest-cov>=4.0 ; extra == 'test'
+- pytest-xdist>=3.0 ; extra == 'test'
+- pytest-mpl ; extra == 'test-extras'
+- pytest-randomly ; extra == 'test-extras'
+requires_python: '>=3.11,!=3.14.1'
+- pypi: https://files.pythonhosted.org/packages/bb/38/926757caaac18a66f057d7544a63620bf360a07d281c9f7ecadd2aa83963/numba-0.67.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+name: numba
+version: 0.67.0
+sha256: f63d43db06b4756424d6d2484737c902e0ae944a0eec3e8b0b4de2c695b15caa
+requires_dist:
+- llvmlite>=0.49.0.dev0,<0.50
+- numpy>=1.22,<2.6
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/fb/53/78c98ef5c8b2b784453487f3e4d6c017b20747c58b470393e230c78d18e8/numcodecs-0.16.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+name: numcodecs
+version: 0.16.5
+sha256: ad1a379a45bd3491deab8ae6548313946744f868c21d5340116977ea3be5b1d6
+requires_dist:
+- numpy>=1.24
+- typing-extensions
+- msgpack ; extra == 'msgpack'
+- zfpy>=1.0.0 ; extra == 'zfpy'
+- pcodec>=0.3,<0.4 ; extra == 'pcodec'
+- crc32c>=2.7 ; extra == 'crc32c'
+- google-crc32c>=1.5 ; extra == 'google-crc32c'
+- sphinx ; extra == 'docs'
+- sphinx-issues ; extra == 'docs'
+- pydata-sphinx-theme ; extra == 'docs'
+- numpydoc ; extra == 'docs'
+- coverage ; extra == 'test'
+- pytest ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- pyzstd ; extra == 'test'
+- importlib-metadata ; extra == 'test-extras'
+- crc32c ; extra == 'test-extras'
+requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+name: numpy
+version: 2.5.2
+sha256: 3cdec01fa790a186d430433fdd4d4ffb70eed6f0eeb4bf05c8dbe2dce0a9bcb8
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/fc/6a/1000cad1700ab0af4d1b1d0a9c23c34badddb4f547c008bde2a6c61968f1/ome_types-0.6.3-py3-none-any.whl
+name: ome-types
+version: 0.6.3
+sha256: ce9753ff351bbc534ee5c5038d3cf60b1e4c13d69ad2e6b5a5b75de2a52521a5
+requires_dist:
+- pydantic-core>=2.20.0 ; python_full_version >= '3.13'
+- pydantic-extra-types>=2.0.0
+- pydantic>=2.4.0
+- xsdata>=24.4
+- ruff==0.13.2 ; extra == 'build'
+- xsdata[cli]>=24.7 ; extra == 'build'
+- lxml>=4.8.0 ; extra == 'lxml'
+- lxml>=5.0 ; python_full_version >= '3.11' and extra == 'lxml'
+- lxml>=5.3 ; python_full_version >= '3.13' and extra == 'lxml'
+- pint>=0.15 ; extra == 'pint'
+- pint>=0.25 ; python_full_version >= '3.13' and extra == 'pint'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/e0/a5/03e8ae6a8c4dfcc28561354f5ea20073c7b0a640b301b54169a3bf709e87/ome_zarr-0.19.1-py3-none-any.whl
+name: ome-zarr
+version: 0.19.1
+sha256: 92e5b9de0e50f6fc93bbbbd04d7ec3da49d5b1f72b6db1ca3df216dceaa24f23
+requires_dist:
+- numpy
+- dask>=2025.2.0,!=2025.12.*,!=2026.1.*,!=2026.2.*
+- zarr>=3.0.0
+- fsspec[s3]>=0.8,!=2021.7.0,!=2023.9.0
+- aiohttp
+- requests
+- scikit-image>=0.19.0
+- toolz
+- rangehttpserver
+- transformnd>=0.6.0,<0.8.0
+- ome-zarr-models>=1.8.1
+- deprecated
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/2d/70/9ab676f57fe2cb5457db80dd0cc4648b02cbe777d47f159e357391a1e00a/ome_zarr_models-1.8.1-py3-none-any.whl
+name: ome-zarr-models
+version: 1.8.1
+sha256: 8231b4f2ceae70992c0b3bbf0e7405016eb14998aaf1546d83c9ff87c0349638
+requires_dist:
+- numpy
+- pydantic-zarr>=0.10.0 ; python_full_version >= '3.14'
+- pydantic-zarr>=0.8.2
+- pydantic>=2.11.5,<2.13
+- zarr>=3.1.1
+- fsspec[http]==2026.4.0 ; extra == 'docs'
+- griffe-fieldz==0.5.0 ; extra == 'docs'
+- matplotlib==3.10.9 ; extra == 'docs'
+- mkdocs-jupyter==0.26.3 ; extra == 'docs'
+- mkdocs-material==9.7.6 ; extra == 'docs'
+- mkdocs==1.6.1 ; extra == 'docs'
+- mkdocstrings-python==2.0.3 ; extra == 'docs'
+- rich==15.0.0 ; extra == 'docs'
+requires_python: '>=3.12'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+md5: 16e3034a330cc625f2c685edec60cf4e
+depends:
+- __glibc >=2.17,<3.0.a0
+- ca-certificates
+- libgcc >=15
+license: Apache-2.0
+license_family: Apache
+purls: []
+size: 3202955
+timestamp: 1787698780103
+- pypi: https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl
+name: opt-einsum
+version: 3.4.0
+sha256: 69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd
+requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/fe/98/6a63875d66bef096d0c040f0cba9d0b14436df88b130d7f779c3dfa59759/optree-0.20.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+name: optree
+version: 0.20.0
+sha256: 5c4ed341ea1ee7eb04eff01527b88a868cb19aac672a667e0aefadf7d14c0260
+requires_dist:
+- typing-extensions>=4.10.0
+- typing-extensions>=4.12.0 ; python_full_version >= '3.13'
+- typing-extensions>=4.14.0 ; python_full_version >= '3.15'
+- attrs ; extra == 'attrs'
+- jax ; extra == 'jax'
+- numpy ; extra == 'numpy'
+- torch ; extra == 'torch'
+- cpplint ; extra == 'lint'
+- doc8 ; extra == 'lint'
+- mypy ; extra == 'lint'
+- pre-commit ; extra == 'lint'
+- pyenchant ; extra == 'lint'
+- pylint[spelling] ; extra == 'lint'
+- ruff ; extra == 'lint'
+- xdoctest ; extra == 'lint'
+- pytest ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- covdefaults ; extra == 'test'
+- rich ; extra == 'test'
+- typing-extensions==4.10.0 ; python_full_version < '3.13' and sys_platform == 'linux' and extra == 'test'
+- typing-extensions==4.10.0 ; python_full_version < '3.13' and sys_platform == 'darwin' and extra == 'test'
+- typing-extensions==4.10.0 ; python_full_version < '3.13' and sys_platform == 'win32' and extra == 'test'
+- typing-extensions==4.12.0 ; python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform == 'linux' and extra == 'test'
+- typing-extensions==4.12.0 ; python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform == 'darwin' and extra == 'test'
+- typing-extensions==4.12.0 ; python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform == 'win32' and extra == 'test'
+- typing-extensions==4.14.0 ; python_full_version >= '3.15' and sys_platform == 'linux' and extra == 'test'
+- typing-extensions==4.14.0 ; python_full_version >= '3.15' and sys_platform == 'darwin' and extra == 'test'
+- typing-extensions==4.14.0 ; python_full_version >= '3.15' and sys_platform == 'win32' and extra == 'test'
+- sphinx~=8.0 ; extra == 'docs'
+- sphinx-autoapi ; extra == 'docs'
+- sphinx-autobuild ; extra == 'docs'
+- sphinx-autodoc-typehints ; extra == 'docs'
+- sphinx-copybutton ; extra == 'docs'
+- sphinx-rtd-theme ; extra == 'docs'
+- sphinxcontrib-bibtex ; extra == 'docs'
+- docutils ; extra == 'docs'
+- attrs ; extra == 'docs'
+- jax[cpu] ; extra == 'docs'
+- numpy ; extra == 'docs'
+- torch ; extra == 'docs'
+requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.3-pyhc364b38_0.conda
+sha256: c432626b16768b8dab228bfb706f7060c2d462a21c516d240f68f2f902b5a044
+md5: 936687ed80f295a1f5dbcf8bd34c252c
+depends:
+- python >=3.9
+- python
+license: Apache-2.0
+license_family: APACHE
+purls:
+- pkg:pypi/packaging?source=hash-mapping
+size: 116363
+timestamp: 1785888127370
+- pypi: https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+name: pandas
+version: 3.0.5
+sha256: d373ce03ffd84010ed9839fa73672a9c8256990532e158440c0085db7d914b34
+requires_dist:
+- numpy>=1.26.0 ; python_full_version < '3.14'
+- numpy>=2.3.3 ; python_full_version >= '3.14'
+- python-dateutil>=2.8.2
+- tzdata ; sys_platform == 'win32'
+- tzdata ; sys_platform == 'emscripten'
+- hypothesis>=6.116.0 ; extra == 'test'
+- pytest>=8.3.4,<9.1 ; extra == 'test'
+- pytest-xdist>=3.6.1 ; extra == 'test'
+- pyarrow>=13.0.0 ; extra == 'pyarrow'
+- bottleneck>=1.4.2 ; extra == 'performance'
+- numba>=0.60.0 ; extra == 'performance'
+- numexpr>=2.10.2 ; extra == 'performance'
+- scipy>=1.14.1 ; extra == 'computation'
+- xarray>=2024.10.0 ; extra == 'computation'
+- fsspec>=2024.10.0 ; extra == 'fss'
+- s3fs>=2024.10.0 ; extra == 'aws'
+- gcsfs>=2024.10.0 ; extra == 'gcp'
+- odfpy>=1.4.1 ; extra == 'excel'
+- openpyxl>=3.1.5 ; extra == 'excel'
+- python-calamine>=0.3.0 ; extra == 'excel'
+- pyxlsb>=1.0.10 ; extra == 'excel'
+- xlrd>=2.0.1 ; extra == 'excel'
+- xlsxwriter>=3.2.0 ; extra == 'excel'
+- pyarrow>=13.0.0 ; extra == 'parquet'
+- pyarrow>=13.0.0 ; extra == 'feather'
+- pyiceberg>=0.8.1 ; extra == 'iceberg'
+- tables>=3.10.1 ; extra == 'hdf5'
+- pyreadstat>=1.2.8 ; extra == 'spss'
+- sqlalchemy>=2.0.36 ; extra == 'postgresql'
+- psycopg2>=2.9.10 ; extra == 'postgresql'
+- adbc-driver-postgresql>=1.2.0 ; extra == 'postgresql'
+- sqlalchemy>=2.0.36 ; extra == 'mysql'
+- pymysql>=1.1.1 ; extra == 'mysql'
+- sqlalchemy>=2.0.36 ; extra == 'sql-other'
+- adbc-driver-postgresql>=1.2.0 ; extra == 'sql-other'
+- adbc-driver-sqlite>=1.2.0 ; extra == 'sql-other'
+- beautifulsoup4>=4.12.3 ; extra == 'html'
+- html5lib>=1.1 ; extra == 'html'
+- lxml>=5.3.0 ; extra == 'html'
+- lxml>=5.3.0 ; extra == 'xml'
+- matplotlib>=3.9.3 ; extra == 'plot'
+- jinja2>=3.1.5 ; extra == 'output-formatting'
+- tabulate>=0.9.0 ; extra == 'output-formatting'
+- pyqt5>=5.15.9 ; extra == 'clipboard'
+- qtpy>=2.4.2 ; extra == 'clipboard'
+- zstandard>=0.23.0 ; extra == 'compression'
+- pytz>=2020.1 ; extra == 'timezone'
+- adbc-driver-postgresql>=1.2.0 ; extra == 'all'
+- adbc-driver-sqlite>=1.2.0 ; extra == 'all'
+- beautifulsoup4>=4.12.3 ; extra == 'all'
+- bottleneck>=1.4.2 ; extra == 'all'
+- fastparquet>=2024.11.0 ; extra == 'all'
+- fsspec>=2024.10.0 ; extra == 'all'
+- gcsfs>=2024.10.0 ; extra == 'all'
+- html5lib>=1.1 ; extra == 'all'
+- hypothesis>=6.116.0 ; extra == 'all'
+- jinja2>=3.1.5 ; extra == 'all'
+- lxml>=5.3.0 ; extra == 'all'
+- matplotlib>=3.9.3 ; extra == 'all'
+- numba>=0.60.0 ; extra == 'all'
+- numexpr>=2.10.2 ; extra == 'all'
+- odfpy>=1.4.1 ; extra == 'all'
+- openpyxl>=3.1.5 ; extra == 'all'
+- psycopg2>=2.9.10 ; extra == 'all'
+- pyarrow>=13.0.0 ; extra == 'all'
+- pyiceberg>=0.8.1 ; extra == 'all'
+- pymysql>=1.1.1 ; extra == 'all'
+- pyqt5>=5.15.9 ; extra == 'all'
+- pyreadstat>=1.2.8 ; extra == 'all'
+- pytest>=8.3.4 ; extra == 'all'
+- pytest-xdist>=3.6.1 ; extra == 'all'
+- python-calamine>=0.3.0 ; extra == 'all'
+- pytz>=2020.1 ; extra == 'all'
+- pyxlsb>=1.0.10 ; extra == 'all'
+- qtpy>=2.4.2 ; extra == 'all'
+- scipy>=1.14.1 ; extra == 'all'
+- s3fs>=2024.10.0 ; extra == 'all'
+- sqlalchemy>=2.0.36 ; extra == 'all'
+- tables>=3.10.1 ; extra == 'all'
+- tabulate>=0.9.0 ; extra == 'all'
+- xarray>=2024.10.0 ; extra == 'all'
+- xlrd>=2.0.1 ; extra == 'all'
+- xlsxwriter>=3.2.0 ; extra == 'all'
+- zstandard>=0.23.0 ; extra == 'all'
+requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/35/94/ff5ad5b758c61c1b33755e02c3a653d1d41c36891329e76a8e6b6e69e8b1/param-2.4.2-py3-none-any.whl
+name: param
+version: 2.4.2
+sha256: 56f56e991d11cdf9fa8248ca3b1c7d5badfd6b4da3b3886b764b95823d270b07
+requires_dist:
+- aiohttp ; extra == 'all'
+- cloudpickle ; extra == 'all'
+- gmpy2 ; extra == 'all'
+- ipython ; extra == 'all'
+- jsonschema ; extra == 'all'
+- nbval ; extra == 'all'
+- nest-asyncio ; extra == 'all'
+- numpy ; extra == 'all'
+- odfpy ; extra == 'all'
+- openpyxl ; extra == 'all'
+- pandas ; extra == 'all'
+- panel ; extra == 'all'
+- pyarrow ; extra == 'all'
+- pytest ; extra == 'all'
+- pytest-asyncio ; extra == 'all'
+- pytest-cov ; extra == 'all'
+- pytest-xdist ; extra == 'all'
+- tables ; extra == 'all'
+- xlrd ; extra == 'all'
+- aiohttp ; extra == 'examples'
+- pandas ; extra == 'examples'
+- panel ; extra == 'examples'
+- pytest ; extra == 'tests'
+- pytest-asyncio ; extra == 'tests'
+- pytest-cov ; extra == 'tests'
+- odfpy ; extra == 'tests-deser'
+- openpyxl ; extra == 'tests-deser'
+- pyarrow ; extra == 'tests-deser'
+- tables ; extra == 'tests-deser'
+- xlrd ; extra == 'tests-deser'
+- aiohttp ; extra == 'tests-examples'
+- nbval ; extra == 'tests-examples'
+- pandas ; extra == 'tests-examples'
+- panel ; extra == 'tests-examples'
+- pytest ; extra == 'tests-examples'
+- pytest-asyncio ; extra == 'tests-examples'
+- pytest-xdist ; extra == 'tests-examples'
+- aiohttp ; extra == 'tests-full'
+- cloudpickle ; extra == 'tests-full'
+- gmpy2 ; extra == 'tests-full'
+- ipython ; extra == 'tests-full'
+- jsonschema ; extra == 'tests-full'
+- nbval ; extra == 'tests-full'
+- nest-asyncio ; extra == 'tests-full'
+- numpy ; extra == 'tests-full'
+- odfpy ; extra == 'tests-full'
+- openpyxl ; extra == 'tests-full'
+- pandas ; extra == 'tests-full'
+- panel ; extra == 'tests-full'
+- pyarrow ; extra == 'tests-full'
+- pytest ; extra == 'tests-full'
+- pytest-asyncio ; extra == 'tests-full'
+- pytest-cov ; extra == 'tests-full'
+- pytest-xdist ; extra == 'tests-full'
+- tables ; extra == 'tests-full'
+- xlrd ; extra == 'tests-full'
+- cloudpickle ; extra == 'tests-pypy'
+- ipython ; extra == 'tests-pypy'
+- jsonschema ; extra == 'tests-pypy'
+- nest-asyncio ; extra == 'tests-pypy'
+- numpy ; extra == 'tests-pypy'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/71/e7/40fb618334dcdf7c5a316c0e7343c5cd82d3d866edc100d98e29bc945ecd/partd-1.4.2-py3-none-any.whl
+name: partd
+version: 1.4.2
+sha256: 978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f
+requires_dist:
+- locket
+- toolz
+- numpy>=1.20.0 ; extra == 'complete'
+- pandas>=1.3 ; extra == 'complete'
+- pyzmq ; extra == 'complete'
+- blosc ; extra == 'complete'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b1/29/c028a0731e202035f0e2e0bfbf1a3e46ad6c628cbb17f6f1cc9eea5d9ff1/pathlib_abc-0.5.2-py3-none-any.whl
+name: pathlib-abc
+version: 0.5.2
+sha256: 4c9d94cf1b23af417ce7c0417b43333b06a106c01000b286c99de230d95eefbb
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/20/70/cd3cf5cff538323076a879edef02cce6f13f7d75e03d12f211b0a0dbd178/patsy-1.0.3-py2.py3-none-any.whl
+name: patsy
+version: 1.0.3
+sha256: d3dbebe8fd5f46e29912d030b63c6268647b59bf788a99e2af28a30234cf357c
+requires_dist:
+- numpy>=1.4
+- packaging
+- pytest ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- scipy ; extra == 'test'
+requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+name: pillow
+version: 12.3.0
+sha256: 78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91
+requires_dist:
+- furo ; extra == 'docs'
+- olefile ; extra == 'docs'
+- sphinx>=8.2 ; extra == 'docs'
+- sphinx-autobuild ; extra == 'docs'
+- sphinx-copybutton ; extra == 'docs'
+- sphinx-inline-tabs ; extra == 'docs'
+- sphinxext-opengraph ; extra == 'docs'
+- olefile ; extra == 'fpx'
+- olefile ; extra == 'mic'
+- arro3-compute ; extra == 'test-arrow'
+- arro3-core ; extra == 'test-arrow'
+- nanoarrow ; extra == 'test-arrow'
+- pyarrow ; extra == 'test-arrow'
+- coverage>=7.4.2 ; extra == 'tests'
+- defusedxml ; extra == 'tests'
+- markdown2 ; extra == 'tests'
+- olefile ; extra == 'tests'
+- packaging ; extra == 'tests'
+- pytest ; extra == 'tests'
+- pytest-cov ; extra == 'tests'
+- pytest-timeout ; extra == 'tests'
+- pytest-xdist ; extra == 'tests'
+- setuptools ; extra == 'tests'
+- trove-classifiers>=2024.10.12 ; extra == 'tests'
+- defusedxml ; extra == 'xmp'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b8/02/5bf3639f5b77e9b183011c08541c5039ba3d04f5316c70312b48a8e003a9/pims-0.7.tar.gz
+name: pims
+version: '0.7'
+sha256: 55907a4c301256086d2aa4e34a5361b9109f24e375c2071e1117b9491e82946b
+requires_dist:
+- imageio
+- numpy>=1.19
+- packaging
+- slicerator>=0.9.8
+- tifffile
+requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/noarch/pip-24.3.1-pyh8b19718_2.conda
+sha256: da8c8888de10c1e4234ebcaa1550ac2b4b5408ac20f093fe641e4bc8c9c9f3eb
+md5: 04e691b9fadd93a8a9fad87a81d4fd8f
+depends:
+- python >=3.9,<3.13.0a0
+- setuptools
+- wheel
+license: MIT
+license_family: MIT
+purls:
+- pkg:pypi/pip?source=hash-mapping
+size: 1245116
+timestamp: 1734466348103
+- pypi: https://files.pythonhosted.org/packages/27/6e/80993e10a0482f630cef528635789233224f36b1ffd11592aa15d13ff9ce/platformdirs-4.11.7-py3-none-any.whl
+name: platformdirs
+version: 4.11.7
+sha256: 8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl
+name: pooch
+version: 1.9.0
+sha256: f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b
+requires_dist:
+- platformdirs>=2.5.0
+- packaging>=20.0
+- requests>=2.19.0
+- tqdm>=4.41.0,<5.0.0 ; extra == 'progress'
+- paramiko>=2.7.0 ; extra == 'sftp'
+- xxhash>=1.4.3 ; extra == 'xxhash'
+- pytest-httpserver ; extra == 'test'
+- pytest-localftpserver ; extra == 'test'
+requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/procps-ng-4.0.6-h18c060e_0.conda
+sha256: 4ce2e1ee31a6217998f78c31ce7dc0a3e0557d9238b51d49dd20c52d467a126d
+md5: f2c23a77b25efcad57d377b34bd84941
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=14
+- ncurses >=6.5,<7.0a0
+license: GPL-2.0-or-later AND LGPL-2.0-or-later
+license_family: GPL
+purls: []
+size: 593603
+timestamp: 1769710381284
+- pypi: https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+name: propcache
+version: 0.5.2
+sha256: 6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/22/df/c799fe7a05ef16ba853a59db01f3a2c5f7d0676469589ccc4874f76a2a88/protobuf-7.36.1-cp310-abi3-manylinux2014_x86_64.whl
+name: protobuf
+version: 7.36.1
+sha256: 97198b77e369a0abd8e262b8f6c7266c55ddb796a3a12c76d7b8881188ed83aa
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl
+name: psutil
+version: 7.2.2
+sha256: 076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9
+requires_dist:
+- psleak ; extra == 'dev'
+- pytest ; extra == 'dev'
+- pytest-instafail ; extra == 'dev'
+- pytest-xdist ; extra == 'dev'
+- setuptools ; extra == 'dev'
+- abi3audit ; extra == 'dev'
+- black ; extra == 'dev'
+- check-manifest ; extra == 'dev'
+- coverage ; extra == 'dev'
+- packaging ; extra == 'dev'
+- pylint ; extra == 'dev'
+- pyperf ; extra == 'dev'
+- pypinfo ; extra == 'dev'
+- pytest-cov ; extra == 'dev'
+- requests ; extra == 'dev'
+- rstcheck ; extra == 'dev'
+- ruff ; extra == 'dev'
+- sphinx ; extra == 'dev'
+- sphinx-rtd-theme ; extra == 'dev'
+- toml-sort ; extra == 'dev'
+- twine ; extra == 'dev'
+- validate-pyproject[all] ; extra == 'dev'
+- virtualenv ; extra == 'dev'
+- vulture ; extra == 'dev'
+- wheel ; extra == 'dev'
+- colorama ; os_name == 'nt' and extra == 'dev'
+- pyreadline3 ; os_name == 'nt' and extra == 'dev'
+- pywin32 ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+- wheel ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+- wmi ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'dev'
+- psleak ; extra == 'test'
+- pytest ; extra == 'test'
+- pytest-instafail ; extra == 'test'
+- pytest-xdist ; extra == 'test'
+- setuptools ; extra == 'test'
+- pywin32 ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+- wheel ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+- wmi ; implementation_name != 'pypy' and os_name == 'nt' and extra == 'test'
+requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/60/c9/711ca85d79f1ec98f29a5eae2b051e25b4ecec5de3e3c0e2d5c5dcb15664/pyarrow-25.0.1-cp312-cp312-manylinux_2_28_x86_64.whl
+name: pyarrow
+version: 25.0.1
+sha256: 5389cdf79447ed1515c9e31620e6e1e2302249564d603f2ad727d4f6d313e4c3
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8c/b2/23f4032cd1c9744aa8e9ecda43cd4d755fcb209f7f40fae035248f31a679/pyct-0.6.0-py3-none-any.whl
+name: pyct
+version: 0.6.0
+sha256: cfaded7289fca72ddf6579b81459e3ec8db323a508e61c49aa318ee3cd6ff160
+requires_dist:
+- param>=1.7.0
+- pyyaml ; extra == 'cmd'
+- requests ; extra == 'cmd'
+- pytest ; extra == 'tests'
+requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl
+name: pydantic
+version: 2.12.5
+sha256: e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d
+requires_dist:
+- annotated-types>=0.6.0
+- pydantic-core==2.41.5
+- typing-extensions>=4.14.1
+- typing-inspection>=0.4.2
+- email-validator>=2.0.0 ; extra == 'email'
+- tzdata ; python_full_version >= '3.9' and sys_platform == 'win32' and extra == 'timezone'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+name: pydantic-core
+version: 2.41.5
+sha256: eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c
+requires_dist:
+- typing-extensions>=4.14.1
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl
+name: pydantic-extra-types
+version: 2.11.1
+sha256: 1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1
+requires_dist:
+- pydantic>=2.5.2
+- typing-extensions
+- cron-converter>=1.2.2 ; extra == 'all'
+- pendulum>=3.0.0,<4.0.0 ; extra == 'all'
+- phonenumbers>=8,<10 ; extra == 'all'
+- pycountry>=23 ; extra == 'all'
+- pymongo>=4.0.0,<5.0.0 ; extra == 'all'
+- python-ulid>=1,<2 ; python_full_version < '3.9' and extra == 'all'
+- python-ulid>=1,<4 ; python_full_version >= '3.9' and extra == 'all'
+- pytz>=2024.1 ; extra == 'all'
+- semver>=3.0.2 ; extra == 'all'
+- semver~=3.0.2 ; extra == 'all'
+- tzdata>=2024.1 ; extra == 'all'
+- uuid-utils>=0.6.0 ; python_full_version < '3.14' and extra == 'all'
+- cron-converter>=1.2.2 ; extra == 'cron'
+- pendulum>=3.0.0,<4.0.0 ; extra == 'pendulum'
+- phonenumbers>=8,<10 ; extra == 'phonenumbers'
+- pycountry>=23 ; extra == 'pycountry'
+- python-ulid>=1,<2 ; python_full_version < '3.9' and extra == 'python-ulid'
+- python-ulid>=1,<4 ; python_full_version >= '3.9' and extra == 'python-ulid'
+- semver>=3.0.2 ; extra == 'semver'
+- uuid-utils>=0.6.0 ; python_full_version < '3.14' and extra == 'uuid-utils'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl
+name: pydantic-settings
+version: 2.15.0
+sha256: 0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42
+requires_dist:
+- pydantic>=2.7.0
+- python-dotenv>=0.21.0
+- typing-inspection>=0.4.0
+- boto3>=1.35.0 ; extra == 'aws-secrets-manager'
+- azure-identity>=1.16.0 ; extra == 'azure-key-vault'
+- azure-keyvault-secrets>=4.8.0 ; extra == 'azure-key-vault'
+- google-cloud-secret-manager>=2.23.1 ; extra == 'gcp-secret-manager'
+- tomli>=2.0.1 ; extra == 'toml'
+- pyyaml>=6.0.1 ; extra == 'yaml'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/c7/05/04af0ca9c5747c95591a549509ebbb0a986155015de59f1e4c984e3af9ab/pydantic_zarr-0.10.0-py3-none-any.whl
+name: pydantic-zarr
+version: 0.10.0
+sha256: d15769dab43346b070051fdf6e83509d7f55259dd00c6d12be2400935117e230
+requires_dist:
+- numpy>=2.0.0
+- packaging>=21.0
+- pydantic>2.0.0
+- mkdocs-material ; extra == 'docs'
+- mkdocstrings[python] ; extra == 'docs'
+- pydantic==2.12.* ; extra == 'docs'
+- pytest-examples ; extra == 'docs'
+- towncrier ; extra == 'docs'
+- zarr>=3.1.0 ; extra == 'docs'
+- coverage ; extra == 'test'
+- dask==2025.11.0 ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- pytest-examples ; extra == 'test'
+- pytest<8.4 ; extra == 'test'
+- xarray==2025.10.0 ; extra == 'test'
+- zarr>=3.0.0 ; extra == 'test'
+- coverage ; extra == 'test-base'
+- dask==2025.11.0 ; extra == 'test-base'
+- pytest-cov ; extra == 'test-base'
+- pytest-examples ; extra == 'test-base'
+- pytest<8.4 ; extra == 'test-base'
+- xarray==2025.10.0 ; extra == 'test-base'
+- zarr>=3.0.0 ; extra == 'zarr'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl
+name: pygments
+version: 2.21.0
+sha256: 2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9
+requires_dist:
+- colorama>=0.4.6 ; extra == 'windows-terminal'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl
+name: pynndescent
+version: 0.6.0
+sha256: dc8c74844e4c7f5cbd1e0cd6909da86fdc789e6ff4997336e344779c3d5538ef
+requires_dist:
+- scikit-learn>=0.18
+- scipy>=1.0
+- numba>=0.55.0
+- llvmlite>=0.38
+- joblib>=0.11
+- pytest ; extra == 'testing'
+- pypi: https://files.pythonhosted.org/packages/20/c2/247c150f5ca12f8593c20e39115db551b18de5c6cb383006de21b57399e4/pyogrio-0.13.0-cp311-abi3-manylinux_2_28_x86_64.whl
+name: pyogrio
+version: 0.13.0
+sha256: 220a988ce2a26591d6db5c775b07289d4f54cabdf274cc048f0e17a0b9d5be14
+requires_dist:
+- certifi
+- numpy
+- packaging
+- cython>=3.1 ; extra == 'dev'
+- pytest ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- pytest-benchmark ; extra == 'benchmark'
+- geopandas ; extra == 'geopandas'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
+name: pyparsing
+version: 3.3.2
+sha256: 850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d
+requires_dist:
+- railroad-diagrams ; extra == 'diagrams'
+- jinja2 ; extra == 'diagrams'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b8/be/212882c450bba74fc8d7d35cbd57e4af84792f0a56194819d98106b075af/pyproj-3.7.2-cp312-cp312-manylinux_2_28_x86_64.whl
+name: pyproj
+version: 3.7.2
+sha256: 1edc34266c0c23ced85f95a1ee8b47c9035eae6aca5b6b340327250e8e281630
+requires_dist:
+- certifi
+requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.14-h5f976f7_3_cpython.conda
+build_number: 3
+sha256: 14c579b1016da04e4c9f1c5c857272d83ec447317d8c4074a07d59de3cef70ef
+md5: 98be3cf76eca2e8871f907a03aed3b84
+depends:
+- __glibc >=2.17,<3.0.a0
+- bzip2 >=1.0.8,<2.0a0
+- ld_impl_linux-64 >=2.36.1
+- libexpat >=2.8.1,<3.0a0
+- libffi >=3.7.0,<3.8.0a0
+- libgcc >=15
+- liblzma >=5.8.3,<6.0a0
+- libnsl >=2.0.1,<2.1.0a0
+- libpython 3.12.14 h0c77377_3_cpython
+- libsqlite >=3.53.4,<4.0a0
+- libuuid >=2.42.3,<3.0a0
+- libxcrypt >=4.4.38
+- libzlib >=1.3.2,<2.0a0
+- ncurses >=6.6,<7.0a0
+- openssl >=3.5.8,<4.0a0
+- readline >=8.3,<9.0a0
+- tk >=8.6.13,<8.7.0a0
+- tzdata
+constrains:
+- python_abi 3.12.* *_cp312
+license: Python-2.0
+purls: []
+size: 23044161
+timestamp: 1788392496306
+- pypi: https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl
+name: python-dateutil
+version: 2.9.0.post0
+sha256: a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427
+requires_dist:
+- six>=1.5
+requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
+- pypi: https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl
+name: python-dotenv
+version: 1.2.3
+sha256: 904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9
+requires_dist:
+- click>=5.0 ; extra == 'cli'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+name: pyyaml
+version: 6.0.3
+sha256: ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
+requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/2f/43/d7e2b9ad768c07b5473bea3ac7db9ca4d995c09399cbea3d4df1c0bd4955/rangehttpserver-1.4.0-py2.py3-none-any.whl
+name: rangehttpserver
+version: 1.4.0
+sha256: 2a0c6926e4341de4cc19ec861292b005e4194ff497b1eefdeccb2992a5045452
+- pypi: https://files.pythonhosted.org/packages/08/40/5946741473075cfed3f4b42a14839cd1672761191dbecff3aa4648b28f63/readfcs-2.1.0-py2.py3-none-any.whl
+name: readfcs
+version: 2.1.0
+sha256: c68fdbe9c93841687d2be7ea49e2b2becc04fcf8c3d6b6d8f48e2892233e0dba
+requires_dist:
+- flowio
+- anndata
+- pre-commit ; extra == 'dev'
+- nox ; extra == 'dev'
+- pytest>=6.0 ; extra == 'dev'
+- pytest-cov ; extra == 'dev'
+- nbproject-test ; extra == 'dev'
+- laminci ; extra == 'dev'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+md5: 69c01c781e7c8190bbdaf79e3848c5ca
+depends:
+- __glibc >=2.17,<3.0.a0
+- libgcc >=15
+- ncurses >=6.6,<7.0a0
+license: GPL-3.0-only
+license_family: GPL
+purls: []
+size: 348899
+timestamp: 1787033801506
+- pypi: https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl
+name: requests
+version: 2.34.2
+sha256: 2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0
+requires_dist:
+- charset-normalizer>=2,<4
+- idna>=2.5,<4
+- urllib3>=1.26,<3
+- certifi>=2023.5.7
+- pysocks>=1.5.6,!=1.5.7 ; extra == 'socks'
+- chardet>=3.0.2,<8 ; extra == 'use-chardet-on-py3'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl
+name: rich
+version: 15.0.0
+sha256: 33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb
+requires_dist:
+- ipywidgets>=7.5.1,<9 ; extra == 'jupyter'
+- markdown-it-py>=2.2.0
+- pygments>=2.13.0,<3.0.0
+requires_python: '>=3.9.0'
+- pypi: https://files.pythonhosted.org/packages/98/cc/bcde19a37952ecc58e7d9d67ecaa048e1e21b17d014ce0863a6a6101e606/s3fs-2026.7.0-py3-none-any.whl
+name: s3fs
+version: 2026.7.0
+sha256: 64edf3c01ebffab1eec38ff9c09eefbf86a3db14c87d248f795da0e7b801d698
+requires_dist:
+- aiobotocore>=2.19.0,<4.0.0
+- fsspec>=2026.7.0,<2026.7.1
+- aiohttp>=3.9.0,!=4.0.0a0,!=4.0.0a1
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/6f/5c/b8cd4faf65463e7ba3a78d8dd4f60dab9e1b330eb395bd8f654c3b194b63/scanpy-1.12.4-py3-none-any.whl
+name: scanpy
+version: 1.12.4
+sha256: a12a7ca9500e4b247fbb5fb9318fb204907125e411183bad3e9c62e5b988f37c
+requires_dist:
+- anndata>=0.10.8
+- certifi
+- fast-array-utils[accel,sparse]>=1.4
+- h5py>=3.11
+- joblib
+- legacy-api-wrap>=1.5
+- matplotlib>=3.10
+- natsort
+- networkx>=2.8.8
+- numba>=0.60
+- numpy>=2
+- packaging>=25
+- pandas>=2.3
+- patsy
+- pynndescent>=0.5.13
+- scikit-learn>=1.6
+- scipy>=1.13
+- scverse-misc>=0.0.6
+- seaborn>=0.13.2
+- session-info2
+- statsmodels>=0.14.5
+- tqdm
+- typing-extensions ; python_full_version < '3.13'
+- umap-learn>=0.5.12
+- bbknn ; extra == 'bbknn'
+- anndata[dask] ; extra == 'dask'
+- dask[array]>=2024.5.1 ; extra == 'dask'
+- anndata[dask] ; extra == 'dask-ml'
+- dask-ml ; extra == 'dask-ml'
+- dask[array]>=2024.5.1 ; extra == 'dask-ml'
+- harmonypy ; extra == 'harmony'
+- igraph>=0.10.8 ; extra == 'leiden'
+- leidenalg>=0.10.1 ; extra == 'leiden'
+- igraph ; extra == 'louvain'
+- louvain>=0.8.2 ; extra == 'louvain'
+- setuptools ; extra == 'louvain'
+- magic-impute>=2.0.4 ; extra == 'magic'
+- igraph ; extra == 'paga'
+- colour-science ; extra == 'plotting'
+- cudf>=0.9 ; extra == 'rapids'
+- cugraph>=0.9 ; extra == 'rapids'
+- cuml>=0.9 ; extra == 'rapids'
+- scanorama ; extra == 'scanorama'
+- scikit-image>=0.23.1 ; extra == 'scrublet'
+- scikit-misc>=0.5.1 ; extra == 'skmisc'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/f4/a2/70401a107d6d7466d64b466927e6b96fcefa99d57494b972608e2f8be50f/scikit_image-0.26.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+name: scikit-image
+version: 0.26.0
+sha256: 7df650e79031634ac90b11e64a9eedaf5a5e06fcd09bcd03a34be01745744466
+requires_dist:
+- numpy>=1.24
+- scipy>=1.11.4
+- networkx>=3.0
+- pillow>=10.1
+- imageio>=2.33,!=2.35.0
+- tifffile>=2022.8.12
+- packaging>=21
+- lazy-loader>=0.4
+- meson-python>=0.16 ; extra == 'build'
+- ninja>=1.11.1.1 ; extra == 'build'
+- cython>=3.0.8,!=3.2.0b1 ; extra == 'build'
+- pythran>=0.16 ; extra == 'build'
+- numpy>=2.0 ; extra == 'build'
+- spin==0.13 ; extra == 'build'
+- build>=1.2.1 ; extra == 'build'
+- pooch>=1.6.0 ; extra == 'data'
+- pre-commit ; extra == 'developer'
+- ipython ; extra == 'developer'
+- docstub==0.3.0.post0 ; extra == 'developer'
+- scikit-image[asv] ; extra == 'developer'
+- asv ; sys_platform != 'emscripten' and extra == 'asv'
+- sphinx>=8.0 ; extra == 'docs'
+- sphinx-gallery[parallel]>=0.18 ; extra == 'docs'
+- numpydoc>=1.7 ; extra == 'docs'
+- sphinx-copybutton ; extra == 'docs'
+- matplotlib>=3.7 ; extra == 'docs'
+- dask[array]>=2023.2.0 ; extra == 'docs'
+- pandas>=2.0 ; extra == 'docs'
+- seaborn>=0.11 ; extra == 'docs'
+- pooch>=1.6 ; extra == 'docs'
+- tifffile>=2022.8.12 ; extra == 'docs'
+- myst-parser ; extra == 'docs'
+- intersphinx-registry>=0.2411.14 ; extra == 'docs'
+- ipywidgets ; extra == 'docs'
+- ipykernel ; extra == 'docs'
+- plotly>=5.20 ; extra == 'docs'
+- kaleido==0.2.1 ; extra == 'docs'
+- scikit-learn>=1.2 ; extra == 'docs'
+- sphinx-design>=0.5 ; extra == 'docs'
+- pydata-sphinx-theme>=0.16 ; extra == 'docs'
+- pywavelets>=1.6 ; extra == 'docs'
+- pytest-doctestplus>=1.6.0 ; extra == 'docs'
+- simpleitk ; sys_platform != 'emscripten' and extra == 'optional'
+- scikit-learn>=1.2 ; extra == 'optional'
+- pyamg>=5.2 ; python_full_version < '3.14' and sys_platform != 'emscripten' and extra == 'optional'
+- scikit-image[optional-free-threaded] ; extra == 'optional'
+- astropy>=6.0 ; extra == 'optional-free-threaded'
+- dask[array]>=2023.2.0 ; extra == 'optional-free-threaded'
+- matplotlib>=3.7 ; extra == 'optional-free-threaded'
+- pooch>=1.6.0 ; sys_platform != 'emscripten' and extra == 'optional-free-threaded'
+- pywavelets>=1.6 ; extra == 'optional-free-threaded'
+- numpydoc>=1.7 ; extra == 'test'
+- pooch>=1.6.0 ; sys_platform != 'emscripten' and extra == 'test'
+- pytest>=8.3 ; extra == 'test'
+- pytest-cov>=2.11.0 ; extra == 'test'
+- pytest-pretty ; extra == 'test'
+- pytest-localserver ; extra == 'test'
+- pytest-faulthandler ; extra == 'test'
+- pytest-doctestplus>=1.6.0 ; extra == 'test'
+requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+name: scikit-learn
+version: 1.9.0
+sha256: 056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8
+requires_dist:
+- numpy>=1.24.1
+- scipy>=1.10.0
+- joblib>=1.4.0
+- narwhals>=2.0.1
+- threadpoolctl>=3.5.0
+- numpy>=1.24.1 ; extra == 'build'
+- scipy>=1.10.0 ; extra == 'build'
+- cython>=3.1.2 ; extra == 'build'
+- meson-python>=0.17.1 ; extra == 'build'
+- numpy>=1.24.1 ; extra == 'install'
+- scipy>=1.10.0 ; extra == 'install'
+- joblib>=1.4.0 ; extra == 'install'
+- narwhals>=2.0.1 ; extra == 'install'
+- threadpoolctl>=3.5.0 ; extra == 'install'
+- matplotlib>=3.6.1 ; extra == 'benchmark'
+- pandas>=1.5.0 ; extra == 'benchmark'
+- memory-profiler>=0.57.0 ; extra == 'benchmark'
+- matplotlib>=3.6.1 ; extra == 'docs'
+- scikit-image>=0.22.0 ; extra == 'docs'
+- pandas>=1.5.0 ; extra == 'docs'
+- rich>=14.1.0 ; extra == 'docs'
+- seaborn>=0.13.0 ; extra == 'docs'
+- memory-profiler>=0.57.0 ; extra == 'docs'
+- sphinx>=7.3.7 ; extra == 'docs'
+- sphinx-copybutton>=0.5.2 ; extra == 'docs'
+- sphinx-gallery>=0.17.1 ; extra == 'docs'
+- numpydoc>=1.2.0 ; extra == 'docs'
+- pillow>=12.1.1 ; extra == 'docs'
+- pooch>=1.8.0 ; extra == 'docs'
+- sphinx-prompt>=1.4.0 ; extra == 'docs'
+- sphinxext-opengraph>=0.9.1 ; extra == 'docs'
+- plotly>=5.22.0 ; extra == 'docs'
+- polars>=0.20.30 ; extra == 'docs'
+- sphinx-design>=0.6.0 ; extra == 'docs'
+- sphinxcontrib-sass>=0.3.4 ; extra == 'docs'
+- pydata-sphinx-theme>=0.15.3 ; extra == 'docs'
+- sphinx-remove-toctrees>=1.0.0.post1 ; extra == 'docs'
+- towncrier>=24.8.0 ; extra == 'docs'
+- matplotlib>=3.6.1 ; extra == 'examples'
+- scikit-image>=0.22.0 ; extra == 'examples'
+- pandas>=1.5.0 ; extra == 'examples'
+- rich>=14.1.0 ; extra == 'examples'
+- seaborn>=0.13.0 ; extra == 'examples'
+- pooch>=1.8.0 ; extra == 'examples'
+- plotly>=5.22.0 ; extra == 'examples'
+- matplotlib>=3.6.1 ; extra == 'tests'
+- pandas>=1.5.0 ; extra == 'tests'
+- rich>=14.1.0 ; extra == 'tests'
+- pytest>=7.1.2 ; extra == 'tests'
+- pytest-cov>=2.9.0 ; extra == 'tests'
+- ruff>=0.12.2 ; extra == 'tests'
+- mypy>=1.15 ; extra == 'tests'
+- pyamg>=5.0.0 ; extra == 'tests'
+- polars>=0.20.30 ; extra == 'tests'
+- pyarrow>=13.0.0 ; extra == 'tests'
+- numpydoc>=1.2.0 ; extra == 'tests'
+- pooch>=1.8.0 ; extra == 'tests'
+- conda-lock==3.0.1 ; extra == 'maintenance'
+requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/df/64/ff35eb9e54894cf471ff4716abd3c81eb0a0626869217ce3e6ba4ccf17d7/scipy-1.18.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+name: scipy
+version: 1.18.1
+sha256: f55fa87b6c612ecd6b058f167c53231b1d14e412efe361d3d6e38b3631c73218
+requires_dist:
+- numpy>=2.0.0,<2.8
+- pytest>=8.0.0 ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- pytest-timeout ; extra == 'test'
+- pytest-xdist ; extra == 'test'
+- asv ; extra == 'test'
+- mpmath ; extra == 'test'
+- gmpy2 ; extra == 'test'
+- threadpoolctl ; extra == 'test'
+- scikit-umfpack ; extra == 'test'
+- pooch ; extra == 'test'
+- hypothesis>=6.30 ; extra == 'test'
+- array-api-strict>=2.3.1 ; extra == 'test'
+- cython ; extra == 'test'
+- meson ; extra == 'test'
+- ninja ; sys_platform != 'emscripten' and extra == 'test'
+- scipy-doctest>=2.0.0 ; extra == 'test'
+- sphinx>=5.0.0,<8.2.0 ; extra == 'doc'
+- intersphinx-registry ; extra == 'doc'
+- pydata-sphinx-theme>=0.15.2 ; extra == 'doc'
+- sphinx-copybutton ; extra == 'doc'
+- sphinx-design>=0.4.0 ; extra == 'doc'
+- matplotlib>=3.5 ; extra == 'doc'
+- numpydoc ; extra == 'doc'
+- jupytext ; extra == 'doc'
+- myst-nb>=1.2.0 ; extra == 'doc'
+- pooch ; extra == 'doc'
+- jupyterlite-sphinx>=0.19.1 ; extra == 'doc'
+- jupyterlite-pyodide-kernel ; extra == 'doc'
+- linkify-it-py ; extra == 'doc'
+- tabulate ; extra == 'doc'
+- click<8.3.0 ; extra == 'dev'
+- spin ; extra == 'dev'
+- mypy==1.19.1 ; extra == 'dev'
+- pyrefly==0.63.0 ; extra == 'dev'
+- typing-extensions ; extra == 'dev'
+- types-psutil ; extra == 'dev'
+- pycodestyle ; extra == 'dev'
+- ruff>=0.12.0 ; extra == 'dev'
+- cython-lint>=0.12.2 ; extra == 'dev'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/26/13/64f304e0ee7be3ed7da25dd4167a34090aa91b7705330c60cce7ed8bf28e/scverse_misc-0.1.4-py3-none-any.whl
+name: scverse-misc
+version: 0.1.4
+sha256: 3bed8a66ce79c296d621c0227299ecc3101d6ab2819f18dca1f565efe8ae0e67
+requires_dist:
+- session-info2
+- typing-extensions ; python_full_version < '3.13'
+- anndata ; extra == 'datasets'
+- pooch ; extra == 'datasets'
+- pyyaml ; extra == 'datasets'
+- tqdm ; extra == 'datasets'
+- pydantic-settings ; extra == 'settings'
+- python-dotenv ; extra == 'settings'
+- spatialdata ; extra == 'spatialdata'
+- jinja2 ; extra == 'sphinx'
+- pydocstring-rs>=0.4.1 ; extra == 'sphinx'
+- sphinx>=9 ; extra == 'sphinx'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
+name: seaborn
+version: 0.13.2
+sha256: 636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987
+requires_dist:
+- numpy>=1.20,!=1.24.0
+- pandas>=1.2
+- matplotlib>=3.4,!=3.6.1
+- pytest ; extra == 'dev'
+- pytest-cov ; extra == 'dev'
+- pytest-xdist ; extra == 'dev'
+- flake8 ; extra == 'dev'
+- mypy ; extra == 'dev'
+- pandas-stubs ; extra == 'dev'
+- pre-commit ; extra == 'dev'
+- flit ; extra == 'dev'
+- numpydoc ; extra == 'docs'
+- nbconvert ; extra == 'docs'
+- ipykernel ; extra == 'docs'
+- sphinx<6.0.0 ; extra == 'docs'
+- sphinx-copybutton ; extra == 'docs'
+- sphinx-issues ; extra == 'docs'
+- sphinx-design ; extra == 'docs'
+- pyyaml ; extra == 'docs'
+- pydata-sphinx-theme==0.10.0rc2 ; extra == 'docs'
+- scipy>=1.7 ; extra == 'stats'
+- statsmodels>=0.12 ; extra == 'stats'
+requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/9b/41/b5af3c12d874fcbdb45abd67500aff8030de0d350a5d6163da45378609c4/session_info2-0.4.2-py3-none-any.whl
+name: session-info2
+version: 0.4.2
+sha256: dbf5f58769115651fad28e8ffc930b6a848a629a242ce2ecd730d12f5e3e9315
+requires_dist:
+- ipywidgets ; extra == 'jupyter'
+requires_python: '>=3.12'
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-84.0.0-pyh332efcf_0.conda
+sha256: 9e200ee5f9ff19a4d94e4b51c4856d53dec849f91032f345cf0c6bc3d51a7183
+md5: 62ac906f1cd582c6c264c95625cb9d6f
+depends:
+- python >=3.10
+license: MIT
+license_family: MIT
+purls:
+- pkg:pypi/setuptools?source=compressed-mapping
+size: 524488
+timestamp: 1786282924579
+- pypi: https://files.pythonhosted.org/packages/b9/37/e781683abac55dde9771e086b790e554811a71ed0b2b8a1e789b7430dd44/shapely-2.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+name: shapely
+version: 2.1.2
+sha256: 1e7d4d7ad262a48bb44277ca12c7c78cb1b0f56b32c10734ec9a1d30c0b0c54b
+requires_dist:
+- numpy>=1.21
+- pytest ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- scipy-doctest ; extra == 'test'
+- numpydoc==1.1.* ; extra == 'docs'
+- matplotlib ; extra == 'docs'
+- sphinx ; extra == 'docs'
+- sphinx-book-theme ; extra == 'docs'
+- sphinx-remove-toctrees ; extra == 'docs'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
+name: shellingham
+version: 1.5.4
+sha256: 7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686
+requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
+name: six
+version: 1.17.0
+sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
+requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
+- pypi: https://files.pythonhosted.org/packages/e8/ae/fa6cd331b364ad2bbc31652d025f5747d89cbb75576733dfdf8efe3e4d62/slicerator-1.1.0-py3-none-any.whl
+name: slicerator
+version: 1.1.0
+sha256: 167668d48c6d3a5ba0bd3d54b2688e81ee267dc20aef299e547d711e6f3c441a
+- pypi: https://files.pythonhosted.org/packages/31/fb/4d209f10d89033e0c2c2e8241e5775fa63e3a18e21c7061ac14067612f1a/sopa-2.2.11-py3-none-any.whl
+name: sopa
+version: 2.2.11
+sha256: eb8cae729b714c0d3ad225e52dfb71a42e374ca74d05c8308c9316b96e153f73
+requires_dist:
+- anndata>=0.11.0
+- dask[distributed]>=2024.4.1
+- igraph>=0.11.0
+- scanpy>=1.10.4
+- spatialdata-io>=0.3.0
+- spatialdata-plot>=0.2.10
+- spatialdata>=0.7.3
+- typer>=0.9.0
+- loompy>=3.0.7 ; extra == 'baysor'
+- toml>=0.10.2 ; extra == 'baysor'
+- cellpose>=3.0.5 ; extra == 'cellpose'
+- opencv-python>=4.8.0 ; extra == 'cellpose'
+- stardist>=0.9.2 ; extra == 'stardist'
+- tensorflow>=2.18.0 ; extra == 'stardist'
+- tiffslide>=0.3.0 ; extra == 'wsi'
+- torch>=2.1.1 ; extra == 'wsi'
+- torchvision>=0.20.0 ; extra == 'wsi'
+- wsidata>=0.8.0 ; extra == 'wsi'
+requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl
+name: sortedcontainers
+version: 2.4.0
+sha256: a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0
+- pypi: https://files.pythonhosted.org/packages/d0/5a/8ef888a4f56fa2ea5c10a7d6ff02286f503a93ea298bcaa9f51a41a20df8/spatial_image-1.2.3-py3-none-any.whl
+name: spatial-image
+version: 1.2.3
+sha256: b5280386a4d540c32c14cb4fdf74bd0242c99c168a7dac36204b29f8c27ce19a
+requires_dist:
+- numpy
+- xarray-dataclass>=3.0.0
+- xarray>=2024.10.0
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/cf/08/f5cac3e58d1bb092bfb6015104e6cce925bbe10a2cae44428c790d4e5d06/spatialdata-0.8.0-py3-none-any.whl
+name: spatialdata
+version: 0.8.0
+sha256: 75139b0df0e27c4573141a8dbe6b3301b47231571505926ad6a633c046ec1010
+requires_dist:
+- anndata>=0.9.1
+- annsel>=0.1.2
+- click
+- dask-image
+- dask>=2026.3.0
+- datashader
+- distributed>=2026.3.0
+- fsspec[http,s3]
+- geopandas>=0.14
+- multiscale-spatial-image==2.0.3
+- networkx
+- numba>=0.55.0
+- numpy
+- ome-zarr>=0.16.0
+- pandas
+- pooch
+- pyarrow
+- rich
+- scikit-image
+- scipy!=1.17.0
+- setuptools
+- shapely>=2.0.1
+- spatial-image>=1.2.3
+- typing-extensions>=4.8.0
+- universal-pathlib>=0.2.6
+- xarray-spatial>=0.3.5
+- xarray>=2024.10.0
+- zarr>=3.0.0
+- napari-spatialdata[all] ; extra == 'extra'
+- spatialdata-io ; extra == 'extra'
+- spatialdata-plot ; extra == 'extra'
+- torch ; extra == 'torch'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/c9/81/6a081a0db19b9bde838cbed6d46f3e3e540da6673d6c50469287a3719775/spatialdata_io-0.7.1-py3-none-any.whl
+name: spatialdata-io
+version: 0.7.1
+sha256: 2627c09a9a59a62793696ee773a147e6425556190f700ff358f03227423b39f0
+requires_dist:
+- anndata
+- click
+- dask-image
+- h5py
+- imagecodecs
+- joblib
+- numpy
+- ome-types
+- pyarrow
+- readfcs
+- scanpy
+- scikit-image
+- spatialdata>=0.7.3a0
+- tifffile>=2023.8.12
+- xmltodict
+- bump2version ; extra == 'dev'
+- pre-commit ; extra == 'dev'
+- ipython>=8.6.0 ; extra == 'doc'
+- myst-nb ; extra == 'doc'
+- sphinx-autodoc-typehints ; extra == 'doc'
+- sphinx-book-theme>=1.0.0 ; extra == 'doc'
+- sphinx-click ; extra == 'doc'
+- sphinx-copybutton ; extra == 'doc'
+- sphinx-design ; extra == 'doc'
+- sphinx>=4.5,<9 ; extra == 'doc'
+- sphinxcontrib-bibtex>=1.0.0 ; extra == 'doc'
+- spatialdata>=0.7.3a0 ; extra == 'pre'
+- pyarrow!=22 ; extra == 'test'
+- pytest ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- pytest-mock ; extra == 'test'
+requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/48/4f/e8662e55ce2dd27c665b2d13a66f5c9808fc74c560d21ab06876b7ceb224/spatialdata_plot-0.4.2-py3-none-any.whl
+name: spatialdata-plot
+version: 0.4.2
+sha256: 633ffbbbe5a9815e54c1e8b690d22fe738ae00376779d95115a456875c88092d
+requires_dist:
+- matplotlib
+- matplotlib-scalebar
+- scanpy
+- scikit-learn
+- spatialdata>=0.3
+- anybioimage>=0.3,<0.4 ; extra == 'interactive'
+- anywidget ; extra == 'interactive'
+- ipykernel ; extra == 'interactive'
+- ipywidgets ; extra == 'interactive'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/d7/0f/74de01918a2578a1785058fff840f0ff8ee0b9402f811c7721a722242bf9/stardist-0.9.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+name: stardist
+version: 0.9.2
+sha256: 46b0a4e8827a7418d93b8d5527aa22367ec6285af9d41c21a701a4f470c45215
+requires_dist:
+- csbdeep>=0.8.2
+- numpy<3 ; python_full_version >= '3.9'
+- scikit-image
+- numba ; sys_platform != 'darwin' or platform_machine == 'arm64'
+- numba<=0.62.1 ; platform_machine != 'arm64' and sys_platform == 'darwin'
+- llvmlite<=0.45.1 ; platform_machine != 'arm64' and sys_platform == 'darwin'
+- imageio
+- csbdeep[tf1]>=0.8.2 ; extra == 'tf1'
+- pytest ; python_full_version < '3.7' and extra == 'test'
+- pytest>=7.2.0 ; python_full_version >= '3.7' and extra == 'test'
+- bioimageio-core>=0.5.0 ; extra == 'bioimageio'
+- importlib-metadata ; extra == 'bioimageio'
+requires_python: '>=3.6'
+- pypi: https://files.pythonhosted.org/packages/41/c7/aeadca282baf51d7b9c135674bac79ded91f4db79c69c188575d22234342/statsmodels-0.15.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+name: statsmodels
+version: 0.15.0
+sha256: c6f2bd48915cc9b3b95c3c7f6ac363b6f8aaa38172962ba5f7f6885f0dfe57f2
+requires_dist:
+- numpy>=1.23.5,<3
+- scipy>=1.8,!=1.9.2
+- pandas>=1.4,!=2.1.0
+- patsy>=0.5.6
+- packaging>=21.3
+- formulaic>=1.1.0
+- pytest>=8.4.1,<10 ; extra == 'test'
+- pytest-randomly ; extra == 'test'
+- pytest-run-parallel ; extra == 'test'
+- pytest-xdist ; extra == 'test'
+- pytest-cov ; extra == 'test'
+- coverage[toml] ; extra == 'test'
+- meson ; extra == 'test'
+- ninja ; sys_platform != 'emscripten' and extra == 'test'
+- sphinx ; extra == 'doc'
+- pandas!=2.1.0,>=2.2.2 ; extra == 'doc'
+- pydata-sphinx-theme ; extra == 'doc'
+- jupyter ; extra == 'doc'
+- notebook ; extra == 'doc'
+- nbsphinx ; extra == 'doc'
+- nbconvert ; extra == 'doc'
+- pyyaml ; extra == 'doc'
+- pandas-datareader ; extra == 'doc'
+- simplegeneric ; extra == 'doc'
+- seaborn ; extra == 'doc'
+- numpydoc ; extra == 'doc'
+- pymc ; os_name != 'nt' and extra == 'doc'
+- arviz ; os_name != 'nt' and extra == 'doc'
+- jinja2 ; extra == 'doc'
+- pickleshare ; extra == 'doc'
+- pytest>=8.4.1,<10 ; extra == 'doc'
+- cython>=3.0.10,<4 ; extra == 'dev'
+- setuptools-scm~=9.0 ; extra == 'dev'
+- meson-python>=0.18.0 ; extra == 'dev'
+- meson ; extra == 'dev'
+- ninja ; extra == 'dev'
+- matplotlib>=3 ; extra == 'dev'
+- colorama ; extra == 'dev'
+- joblib ; extra == 'dev'
+- pywinpty ; os_name == 'nt' and extra == 'dev'
+- ruff ; extra == 'dev'
+- polars>=1.0.0 ; extra == 'polars'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/02/be/5d2d47b1fb58943194fb59dcf222f7c4e35122ec0ffe8c36e18b5d728f0b/tblib-3.2.2-py3-none-any.whl
+name: tblib
+version: 3.2.2
+sha256: 26bdccf339bcce6a88b2b5432c988b266ebbe63a4e593f6b578b1d2e723d2b76
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/ce/d7/6e71b4ded8ce99cd21add95611ca14af6e9ad4f2baeabdeb79a4a6b3cb1f/tensorflow-2.21.0-cp312-cp312-manylinux_2_27_x86_64.whl
+name: tensorflow
+version: 2.21.0
+sha256: b3b95643c4e70eb925839938fb35cbe142f317ec84af6844ee61513713bb13c0
+requires_dist:
+- absl-py>=1.0.0
+- astunparse>=1.6.0
+- flatbuffers>=25.9.23
+- gast>=0.2.1,!=0.5.0,!=0.5.1,!=0.5.2
+- google-pasta>=0.1.1
+- libclang>=13.0.0
+- opt-einsum>=2.3.2
+- packaging
+- protobuf>=6.31.1,<8.0.0
+- requests>=2.21.0,<3
+- setuptools
+- six>=1.12.0
+- termcolor>=1.1.0
+- typing-extensions>=3.6.6
+- wrapt>=1.11.0
+- grpcio>=1.24.3,<2.0
+- keras>=3.12.0
+- numpy>=1.26.0
+- h5py>=3.11.0,<3.15.0
+- ml-dtypes>=0.5.1,<1.0.0
+- nvidia-cublas-cu12>=12.5.3.2,<13.0 ; extra == 'and-cuda'
+- nvidia-cuda-cupti-cu12>=12.5.82,<13.0 ; extra == 'and-cuda'
+- nvidia-cuda-nvcc-cu12>=12.5.82,<13.0 ; extra == 'and-cuda'
+- nvidia-cuda-nvrtc-cu12>=12.5.82,<13.0 ; extra == 'and-cuda'
+- nvidia-cuda-runtime-cu12>=12.5.82,<13.0 ; extra == 'and-cuda'
+- nvidia-cudnn-cu12>=9.3.0.75,<10.0 ; extra == 'and-cuda'
+- nvidia-cufft-cu12>=11.2.3.61,<12.0 ; extra == 'and-cuda'
+- nvidia-curand-cu12>=10.3.6.82,<11.0 ; extra == 'and-cuda'
+- nvidia-cusolver-cu12>=11.6.3.83,<12.0 ; extra == 'and-cuda'
+- nvidia-cusparse-cu12>=12.5.1.3,<13.0 ; extra == 'and-cuda'
+- nvidia-nccl-cu12>=2.27.7,<3.0 ; extra == 'and-cuda'
+- nvidia-nvjitlink-cu12>=12.5.82,<13.0 ; extra == 'and-cuda'
+- tensorflow-io-gcs-filesystem>=0.23.1 ; python_full_version < '3.13' and sys_platform != 'win32' and extra == 'gcs-filesystem'
+- tensorflow-io-gcs-filesystem>=0.23.1 ; python_full_version < '3.12' and sys_platform == 'win32' and extra == 'gcs-filesystem'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl
+name: termcolor
+version: 3.3.0
+sha256: cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5
+requires_dist:
+- pytest ; extra == 'tests'
+- pytest-cov ; extra == 'tests'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/24/99/4772b8e00a136f3e01236de33b0efda31ee7077203ba5967fcc76da94d65/texttable-1.7.0-py2.py3-none-any.whl
+name: texttable
+version: 1.7.0
+sha256: 72227d592c82b3d7f672731ae73e4d1f88cd8e2ef5b075a7a7f01a23a3743917
+- pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
+name: threadpoolctl
+version: 3.6.0
+sha256: 43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/82/38/05347ae8b1b268c068b3ca38822558038f38c6494604837d7ca3cbcceb9c/tifffile-2026.8.23-py3-none-any.whl
+name: tifffile
+version: 2026.8.23
+sha256: a03045afce67d97cb4ef56a1cd47eae6ab8115c7e84cfedeb5cadbfbb6d14fbe
+requires_dist:
+- numpy>=2.1
+- imagecodecs>=2026.8.16 ; extra == 'codecs'
+- lxml ; extra == 'xml'
+- zarr>=3.3.0 ; extra == 'zarr'
+- fsspec ; extra == 'zarr'
+- kerchunk ; extra == 'zarr'
+- matplotlib ; extra == 'plot'
+- imagecodecs>=2026.8.16 ; extra == 'all'
+- matplotlib ; extra == 'all'
+- lxml ; extra == 'all'
+- zarr>=3.3.0 ; extra == 'all'
+- xarray ; extra == 'all'
+- fsspec ; extra == 'all'
+- kerchunk ; extra == 'all'
+- cmapfile ; extra == 'test'
+- czifile ; extra == 'test'
+- dask ; extra == 'test'
+- fsspec ; extra == 'test'
+- imagecodecs ; extra == 'test'
+- kerchunk ; extra == 'test'
+- lfdfiles ; extra == 'test'
+- lxml ; extra == 'test'
+- ndtiff ; extra == 'test'
+- oiffile ; extra == 'test'
+- psdtags ; extra == 'test'
+- pytest ; extra == 'test'
+- requests ; extra == 'test'
+- roifile ; extra == 'test'
+- xarray ; extra == 'test'
+- zarr ; extra == 'test'
+requires_python: '>=3.12'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+build_number: 104
+sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+depends:
+- libgcc >=15
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.2,<2.0a0
+constrains:
+- xorg-libx11 >=1.8.13,<2.0a0
+license: TCL
+purls: []
+size: 3566806
+timestamp: 1787272857910
+- pypi: https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl
+name: toolz
+version: 1.1.0
+sha256: 15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/6e/de/f2e733f386b85962d1b1dc82cd63d169b5b4580062b35397eac9244a41fe/tornado-6.5.8-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+name: tornado
+version: 6.5.8
+sha256: 547d63f450d570c14fe0e8db2cfb14c9bbd1c2503b4a6612586267955aa47b58
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl
+name: tqdm
+version: 4.70.0
+sha256: 7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953
+requires_dist:
+- colorama ; sys_platform == 'win32'
+- requests ; extra == 'discord'
+- envwrap ; extra == 'discord'
+- slack-sdk ; extra == 'slack'
+- envwrap ; extra == 'slack'
+- requests ; extra == 'telegram'
+- envwrap ; extra == 'telegram'
+- ipywidgets>=6 ; extra == 'notebook'
+requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/e7/dc/f9a644bf4b67a27ea2dfee8b816eb07e0e2f93da8fb4265e49f2b2af2f1e/transformnd-0.7.2-py3-none-any.whl
+name: transformnd
+version: 0.7.2
+sha256: d731c5c461e4831c437f32d69af89deec3ab7728d59ba2414bb4e9043ca3ebaf
+requires_dist:
+- numpy>=2
+- networkx>=3
+- array-api-compat>=1.14
+- typing-extensions>=4.15.0
+- transformnd[pandas] ; extra == 'adapters'
+- transformnd[shapely] ; extra == 'adapters'
+- transformnd[polars] ; extra == 'adapters'
+- transformnd[transforms] ; extra == 'all'
+- transformnd[adapters] ; extra == 'all'
+- molesq>=0.4.0 ; extra == 'movingleastsquares'
+- pandas>=3.0.2 ; extra == 'pandas'
+- polars>=1.40.1 ; extra == 'polars'
+- shapely>=2.1.2 ; extra == 'shapely'
+- morphops>=0.1.13 ; extra == 'thinplatesplines'
+- transformnd[thinplatesplines] ; extra == 'transforms'
+- transformnd[movingleastsquares] ; extra == 'transforms'
+- transformnd[vectorfield] ; extra == 'transforms'
+- transformnd[vectorfield-dask] ; extra == 'transforms'
+- scipy>=1.17.1 ; extra == 'vectorfield'
+- dask>=2026.3.0 ; extra == 'vectorfield-dask'
+- dask-image>=2026.5.0 ; extra == 'vectorfield-dask'
+requires_python: '>=3.12,<4.0'
+- pypi: https://files.pythonhosted.org/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl
+name: typer
+version: 0.27.2
+sha256: b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d
+requires_dist:
+- shellingham>=1.3.0
+- rich>=13.8.0
+- annotated-doc>=0.0.2
+- colorama ; sys_platform == 'win32'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl
+name: typing-extensions
+version: 4.16.0
+sha256: 481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl
+name: typing-inspection
+version: 0.4.4
+sha256: 65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147
+requires_dist:
+- typing-extensions>=4.15.0
+requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+md5: fcb489df604d100968b737f2cb6076c6
+license: LicenseRef-Public-Domain
+purls: []
+size: 118849
+timestamp: 1784250406640
+- pypi: https://files.pythonhosted.org/packages/1b/98/f63318ccbe75c810011fe9233884c5d348d94d90005de1b79e5f93bef9c0/umap_learn-0.5.12-py3-none-any.whl
+name: umap-learn
+version: 0.5.12
+sha256: f2a85d2a2adcb52b541bed9b27a23ca169b56bb1b23283abeebfb8dfb8a42fe5
+requires_dist:
+- numpy>=1.23
+- scipy>=1.3.1
+- scikit-learn>=1.6
+- numba>=0.51.2
+- pynndescent>=0.5
+- tqdm
+- pandas ; extra == 'plot'
+- matplotlib ; extra == 'plot'
+- datashader ; extra == 'plot'
+- bokeh ; extra == 'plot'
+- holoviews ; extra == 'plot'
+- colorcet ; extra == 'plot'
+- seaborn ; extra == 'plot'
+- scikit-image ; extra == 'plot'
+- dask ; extra == 'plot'
+- tensorflow>=2.1 ; extra == 'parametric-umap'
+- tbb>=2019.0 ; extra == 'tbb'
+- pytest ; extra == 'test'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/dd/1a/5d9a402b39ec892d856bbdd9db502ff73ce28cdf4aff72eb1ce1d6843506/universal_pathlib-0.3.10-py3-none-any.whl
+name: universal-pathlib
+version: 0.3.10
+sha256: dfaf2fb35683d2eb1287a3ed7b215e4d6016aa6eaf339c607023d22f90821c66
+requires_dist:
+- fsspec>=2024.5.0
+- pathlib-abc>=0.5.1,<0.6.0
+- pytest>=8 ; extra == 'tests'
+- pytest-sugar>=0.9.7 ; extra == 'tests'
+- pytest-cov>=4.1.0 ; extra == 'tests'
+- pytest-mock>=3.12.0 ; extra == 'tests'
+- pylint>=2.17.4 ; extra == 'tests'
+- mypy>=1.10.0 ; extra == 'tests'
+- pydantic>=2 ; extra == 'tests'
+- pytest-mypy-plugins>=3.1.2 ; extra == 'tests'
+- packaging ; extra == 'tests'
+- mypy>=1.10.0 ; extra == 'typechecking'
+- pytest-mypy-plugins>=3.1.2 ; extra == 'typechecking'
+- fsspec[adl,gcs,github,http,s3,smb,ssh]>=2024.5.0 ; extra == 'dev'
+- s3fs>=2024.5.0 ; extra == 'dev'
+- gcsfs>=2024.5.0 ; extra == 'dev'
+- adlfs>=2024 ; extra == 'dev'
+- huggingface-hub ; extra == 'dev'
+- webdav4[fsspec] ; extra == 'dev'
+- moto[s3,server] ; extra == 'dev'
+- wsgidav ; extra == 'dev'
+- cheroot ; extra == 'dev'
+- pyftpdlib ; extra == 'dev'
+- typing-extensions ; python_full_version < '3.11' and extra == 'dev'
+- pydantic ; extra == 'dev-third-party'
+- pydantic-settings ; extra == 'dev-third-party'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl
+name: urllib3
+version: 2.7.0
+sha256: 9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897
+requires_dist:
+- brotli>=1.2.0 ; platform_python_implementation == 'CPython' and extra == 'brotli'
+- brotlicffi>=1.2.0.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
+- h2>=4,<5 ; extra == 'h2'
+- pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
+- backports-zstd>=1.0.0 ; python_full_version < '3.14' and extra == 'zstd'
+requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.48.0-pyhd8ed1ab_0.conda
+sha256: ba64b29b6d418024cb565081a1799262cb2780d2534ff4c14f76aa858c4286cd
+md5: 9a2124517bfd5d792e0f7b86eefdfeb8
+depends:
+- packaging >=24.0
+- python >=3.10
+license: MIT
+license_family: MIT
+purls:
+- pkg:pypi/wheel?source=compressed-mapping
+size: 34528
+timestamp: 1786613220176
+- conda: https://conda.anaconda.org/conda-forge/linux-64/which-2.25-h171cf75_0.conda
+sha256: 2bf9a40d86d29fd5c30d0febec99d06398143ddeece9ebb175cc5a6d20279943
+md5: f16d4aec5e8135e8e7bba02ef600149e
+depends:
+- __glibc >=2.17,<3.0.a0
+- libstdcxx >=14
+- libgcc >=14
+license: GPL-3.0-only
+license_family: GPL
+purls: []
+size: 38560
+timestamp: 1779439547766
+- pypi: https://files.pythonhosted.org/packages/f8/fd/b20e3cb3cab35131b515edf18e8cd777dff680fc76fc00919481f4e536af/wrapt-2.4.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
+name: wrapt
+version: 2.4.0
+sha256: d7dbbdbfdacb85c2d962fa52db791c77943fd777d600d74c95af2d53b32f5a94
+requires_dist:
+- pytest ; extra == 'dev'
+- setuptools ; extra == 'dev'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/57/5b/28365212062939d213802e5e5fe855cdb231e1c2a93254ba1690066504e3/xarray-2026.7.0-py3-none-any.whl
+name: xarray
+version: 2026.7.0
+sha256: bf9dd130b93806dc78e90c1b7ac24851b31557b888674c53622235691cf21824
+requires_dist:
+- numpy>=1.26
+- packaging>=24.2
+- pandas>=2.2
+- scipy>=1.15 ; extra == 'accel'
+- bottleneck ; extra == 'accel'
+- numbagg>=0.9 ; extra == 'accel'
+- numba>=0.62 ; extra == 'accel'
+- flox>=0.10 ; extra == 'accel'
+- opt-einsum ; extra == 'accel'
+- xarray[accel,etc,io,parallel,viz] ; extra == 'complete'
+- netcdf4>=1.6.0 ; extra == 'io'
+- h5netcdf[h5py]>=1.5.0 ; extra == 'io'
+- pydap ; extra == 'io'
+- scipy>=1.15 ; extra == 'io'
+- zarr>=3.0 ; extra == 'io'
+- fsspec ; extra == 'io'
+- cftime ; extra == 'io'
+- pooch ; extra == 'io'
+- sparse>=0.15 ; extra == 'etc'
+- dask[complete] ; extra == 'parallel'
+- cartopy>=0.24 ; extra == 'viz'
+- matplotlib>=3.10 ; extra == 'viz'
+- nc-time-axis ; extra == 'viz'
+- seaborn ; extra == 'viz'
+- pandas-stubs ; extra == 'types'
+- scipy-stubs ; extra == 'types'
+- types-colorama ; extra == 'types'
+- types-decorator ; extra == 'types'
+- types-defusedxml ; extra == 'types'
+- types-docutils ; extra == 'types'
+- types-networkx ; extra == 'types'
+- types-openpyxl ; extra == 'types'
+- types-pexpect ; extra == 'types'
+- types-psutil ; extra == 'types'
+- types-pycurl ; extra == 'types'
+- types-pygments ; extra == 'types'
+- types-python-dateutil ; extra == 'types'
+- types-pytz ; extra == 'types'
+- types-pyyaml ; extra == 'types'
+- types-requests ; extra == 'types'
+- types-setuptools ; extra == 'types'
+- types-xlrd ; extra == 'types'
+requires_python: '>=3.11'
+- pypi: https://files.pythonhosted.org/packages/bc/ea/bc1de04d06b7c59fc3ff647a11fa248bf80af5a6227647a31c6250c32ce6/xarray_dataclass-3.0.0-py3-none-any.whl
+name: xarray-dataclass
+version: 3.0.0
+sha256: 7956f29005671b2acaa0da700d8f359105dce84ef84f76ce2dd05b76dba3e826
+requires_dist:
+- numpy>=2.0.0
+- typing-extensions>=4.10.0
+- xarray>=2022.3
+- myst-parser>=3.0 ; extra == 'dev'
+- pre-commit>=4.2.0 ; extra == 'dev'
+- pydata-sphinx-theme>=0.14 ; extra == 'dev'
+- pytest>=8.2 ; extra == 'dev'
+- sphinx>=7.1 ; extra == 'dev'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/c1/98/80f1eb371b5b053c0edec957ad10fbf1038a4206b9e25fbd4c5ebe11d5cc/xarray_spatial-0.10.17-py3-none-any.whl
+name: xarray-spatial
+version: 0.10.17
+sha256: 7d0da80fc1563020dec37c74da810ca34d93b773a38f971348408c0cfc8685c3
+requires_dist:
+- numba
+- scipy
+- xarray
+- numpy
+- urllib3
+- zstandard
+- dask[dataframe] ; extra == 'doc'
+- geopandas ; extra == 'doc'
+- jinja2>=2.11 ; extra == 'doc'
+- ipykernel ; extra == 'doc'
+- matplotlib ; extra == 'doc'
+- myst-parser ; extra == 'doc'
+- nbsphinx ; extra == 'doc'
+- numpydoc ; extra == 'doc'
+- pandoc ; extra == 'doc'
+- pydata-sphinx-theme ; extra == 'doc'
+- sphinx ; extra == 'doc'
+- sphinx-panels ; extra == 'doc'
+- sphinx-rtd-theme ; extra == 'doc'
+- matplotlib ; extra == 'examples'
+- geopandas ; extra == 'examples'
+- shapely ; extra == 'examples'
+- matplotlib ; extra == 'plot'
+- shapely>=2.0 ; extra == 'vector'
+- awkward>=1.4 ; extra == 'optional'
+- geopandas ; extra == 'optional'
+- spatialpandas ; extra == 'optional'
+- rtxpy ; extra == 'optional'
+- pyproj ; extra == 'reproject'
+- deflate ; extra == 'geotiff'
+- pyproj ; extra == 'geotiff'
+- dask[array] ; extra == 'dask'
+- dask-geopandas ; extra == 'dask'
+- cupy ; extra == 'gpu'
+- cuspatial ; extra == 'gpu'
+- flake8 ; extra == 'tests'
+- geopandas ; extra == 'tests'
+- hypothesis ; extra == 'tests'
+- isort ; extra == 'tests'
+- matplotlib ; extra == 'tests'
+- noise>=1.2.2 ; extra == 'tests'
+- dask ; extra == 'tests'
+- pyarrow ; extra == 'tests'
+- pyproj ; extra == 'tests'
+- pytest ; extra == 'tests'
+- pytest-cov ; extra == 'tests'
+- scipy ; extra == 'tests'
+- shapely>=2.0 ; extra == 'tests'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl
+name: xmltodict
+version: 1.0.4
+sha256: a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a
+requires_dist:
+- pytest ; extra == 'test'
+- pytest-cov ; extra == 'test'
+requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/d3/92/f0edcbc2f895ecea14a68e492b24c157625e251279a94b172a6b263290e7/xsdata-26.2-py3-none-any.whl
+name: xsdata
+version: '26.2'
+sha256: 85a591a4405d903416afbd4a917e8dda8ea44641a3e66d72134bc2a31b3c16b0
+requires_dist:
+- typing-extensions>=4.12.0
+- click>=8.0.0 ; extra == 'cli'
+- jinja2>=3.0.0 ; extra == 'cli'
+- toposort>=1.9 ; extra == 'cli'
+- ruff>=0.9.8 ; extra == 'cli'
+- mkdocs ; extra == 'docs'
+- mkdocs-gen-files ; extra == 'docs'
+- mkdocs-literate-nav ; extra == 'docs'
+- mkdocs-material ; extra == 'docs'
+- mkdocs-minify-plugin ; extra == 'docs'
+- mkdocstrings[python] ; extra == 'docs'
+- markdown-exec[ansi] ; extra == 'docs'
+- lxml>=5.0.0 ; extra == 'lxml'
+- requests>=2.28.0 ; extra == 'soap'
+- pre-commit>=3.0.0 ; extra == 'test'
+- pytest>=8.0.0 ; extra == 'test'
+- pytest-benchmark>=4.0.0 ; extra == 'test'
+- pytest-cov>=5.0.0 ; extra == 'test'
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/d6/d0/d56c859b8222116f5d68459199f48359e0bf121b6f65a69bf329b3602ba0/yarl-1.24.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+name: yarl
+version: 1.24.5
+sha256: f08c7513ecef5aad65687bfdf6bc601ae9fccd04a42904501f8f7141abad9eb9
+requires_dist:
+- idna>=2.0
+- multidict>=4.0
+- propcache>=0.2.1
+requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/6d/c6/6b726ddf4c3ac5a123f285c3650fa8268902c28ea541a0282867f1336e65/zarr-3.3.0-py3-none-any.whl
+name: zarr
+version: 3.3.0
+sha256: 323bf5366d4f909052ef6e2e03e7481a7434c3ee75d3a981eb3a71fc1ae22cef
+requires_dist:
+- donfig>=0.8
+- google-crc32c>=1.5
+- numcodecs>=0.14
+- numpy>=2
+- packaging>=22.0
+- typing-extensions>=4.14
+- cast-value-rs ; extra == 'cast-value-rs'
+- typer ; extra == 'cli'
+- cupy-cuda12x ; sys_platform != 'darwin' and extra == 'gpu'
+- universal-pathlib ; extra == 'optional'
+- fsspec>=2023.10.0 ; extra == 'remote'
+- obstore>=0.5.1 ; extra == 'remote'
+requires_python: '>=3.12'
+- pypi: https://files.pythonhosted.org/packages/80/ab/11a76c1e2126084fde2639514f24e6111b789b0bfa4fc6264a8975c7e1f1/zict-3.0.0-py2.py3-none-any.whl
+name: zict
+version: 3.0.0
+sha256: 5796e36bd0e0cc8cf0fbc1ace6a68912611c1dbd74750a3f3026b9b9d6a327ae
+requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
+name: zstandard
+version: 0.25.0
+sha256: 5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902
+requires_dist:
+- cffi~=1.17 ; python_full_version < '3.14' and platform_python_implementation != 'PyPy' and extra == 'cffi'
+- cffi>=2.0.0b0 ; python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and extra == 'cffi'
+requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+md5: aa459086047c0e5e27023ab19f8cb86a
+depends:
+- __glibc >=2.17,<3.0.a0
+- libzlib >=1.3.2,<2.0a0
+license: BSD-3-Clause
+license_family: BSD
+purls: []
+size: 601301
+timestamp: 1786599621503

--- a/modules/local/download_stardist_model/environment.yml
+++ b/modules/local/download_stardist_model/environment.yml
@@ -1,0 +1,8 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.12
+  - pip=24.3.1
+  - pip:
+      - sopa[stardist]==2.2.11

--- a/modules/local/download_stardist_model/main.nf
+++ b/modules/local/download_stardist_model/main.nf
@@ -1,0 +1,21 @@
+process DOWNLOAD_STARDIST_MODEL {
+    label "process_single"
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+?         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4b/4bd32528c3d37b7f49f1eb47e4c792ae51d3cc38a792cf832dfd07adf44cd68c/data'
+:         'community.wave.seqera.io/library/python_pip_sopastardist:df074ee8a42c1e8f' }"
+
+    input:
+    val cli_arguments
+
+    output:
+    path "stardist_models"
+
+    script:
+    """
+    mkdir -p ./stardist_models
+
+    sopa download stardist --model-dir ./stardist_models ${cli_arguments}
+    """
+}

--- a/modules/local/patch_segmentation_stardist/main.nf
+++ b/modules/local/patch_segmentation_stardist/main.nf
@@ -8,14 +8,14 @@ process PATCH_SEGMENTATION_STARDIST {
 :         'community.wave.seqera.io/library/python_pip_sopastardist:df074ee8a42c1e8f' }"
 
     input:
-    tuple val(meta), path(sdata_path), val(cli_arguments), val(index), val(n_patches)
+    tuple val(meta), path(sdata_path), val(cli_arguments), val(index), val(n_patches), path(model_dir)
 
     output:
     tuple val(meta), path(sdata_path), path("${index}.parquet"), val(n_patches)
 
     script:
     """
-    export KERAS_HOME="\$PWD/.keras"
+    export KERAS_HOME=${model_dir}
 
     sopa segmentation stardist ${sdata_path} --patch-index ${index} ${cli_arguments}
 

--- a/modules/local/utils.nf
+++ b/modules/local/utils.nf
@@ -73,6 +73,10 @@ def extractSubArgs(Map args, String group) {
             gaussian_sigma: args.gaussian_sigma,
             method_kwargs: args.stardist_kwargs,
         ]
+    } else if (group == "download_stardist") {
+        return [
+            model_type: args.stardist_model_type,
+        ]
     } else if (group == "baysor") {
         return [
             config: [

--- a/modules/local/utils.nf
+++ b/modules/local/utils.nf
@@ -55,6 +55,12 @@ def extractSubArgs(Map args, String group) {
             gaussian_sigma: args.gaussian_sigma,
             method_kwargs: args.cellpose_kwargs,
         ]
+    } else if (group == "download_cellpose") {
+        return [
+            model_type: args.cellpose_model_type,
+            pretrained_model: args.pretrained_model,
+            method_kwargs: args.cellpose_kwargs,
+        ]
     } else if (group == "stardist") {
         return [
             model_type: args.stardist_model_type,

--- a/subworkflows/local/cellpose/main.nf
+++ b/subworkflows/local/cellpose/main.nf
@@ -1,3 +1,4 @@
+include { DOWNLOAD_CELLPOSE_MODEL } from '../../../modules/local/download_cellpose_model'
 include { PATCH_SEGMENTATION_CELLPOSE } from '../../../modules/local/patch_segmentation_cellpose'
 include { RESOLVE_CELLPOSE } from '../../../modules/local/resolve_cellpose'
 include { argsCLI } from '../../../modules/local/utils'
@@ -11,9 +12,12 @@ workflow CELLPOSE {
 
     cellpose_args = argsCLI("cellpose")
 
+    ch_model_dir = DOWNLOAD_CELLPOSE_MODEL(argsCLI("download_cellpose")).first()
+
     ch_patches
         .map { meta, sdata_path, patches_file_image -> [meta, sdata_path, patches_file_image.text.trim().toInteger()] }
         .flatMap { meta, sdata_path, n_patches -> (0..<n_patches).collect { index -> [meta, sdata_path, cellpose_args, index, n_patches] } }
+        .combine(ch_model_dir)
         .set { ch_cellpose }
 
     ch_segmented = PATCH_SEGMENTATION_CELLPOSE(ch_cellpose)

--- a/subworkflows/local/stardist/main.nf
+++ b/subworkflows/local/stardist/main.nf
@@ -1,3 +1,4 @@
+include { DOWNLOAD_STARDIST_MODEL } from '../../../modules/local/download_stardist_model'
 include { PATCH_SEGMENTATION_STARDIST } from '../../../modules/local/patch_segmentation_stardist'
 include { RESOLVE_STARDIST } from '../../../modules/local/resolve_stardist'
 include { argsCLI } from '../../../modules/local/utils'
@@ -11,9 +12,12 @@ workflow STARDIST {
 
     stardist_args = argsCLI("stardist")
 
+    ch_model_dir = DOWNLOAD_STARDIST_MODEL(argsCLI("download_stardist")).first()
+
     ch_patches
         .map { meta, sdata_path, patches_file_image -> [meta, sdata_path, patches_file_image.text.trim().toInteger()] }
         .flatMap { meta, sdata_path, n_patches -> (0..<n_patches).collect { index -> [meta, sdata_path, stardist_args, index, n_patches] } }
+        .combine(ch_model_dir)
         .set { ch_stardist }
 
     ch_segmented = PATCH_SEGMENTATION_STARDIST(ch_stardist)

--- a/tests/cellpose.nf.test.snap
+++ b/tests/cellpose.nf.test.snap
@@ -1,7 +1,7 @@
 {
     "-profile test_cellpose": {
         "content": [
-            8,
+            9,
             {
                 "RESOLVE_CELLPOSE": {
                     "sopa": "2.2.11",
@@ -259,7 +259,7 @@
                 
             ]
         ],
-        "timestamp": "2026-09-04T17:31:42.778116",
+        "timestamp": "2026-09-07T17:22:57.66274",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "26.04.6"


### PR DESCRIPTION
Add process to download pre-trained models for StarDist and Cellpose. Now the the model is downloaded once instead of being downloaded concurrently by every patch segmentation task.